### PR TITLE
Use Config to Determine Split Slug

### DIFF
--- a/src/ducks/splits.js
+++ b/src/ducks/splits.js
@@ -70,7 +70,7 @@ const fetchSplit = (user) => {
       type: FETCH_SPLIT,
     });
 
-    Split.load(config.projectSlug).then((splits) => {
+    Split.load(config.zooniverseLinks.projectSlug).then((splits) => {
       let variant = VARIANT_TYPES.INDIVIDUAL;
 
       const split = splits && splits['classifier.collaborative'];

--- a/src/ducks/splits.js
+++ b/src/ducks/splits.js
@@ -1,5 +1,6 @@
 import { Split } from 'seven-ten';
 import apiClient from 'panoptes-client/lib/api-client.js';
+import { config } from '../config';
 
 const FETCH_SPLIT = 'FETCH_SPLIT';
 const FETCH_SPLIT_SUCCESS = 'FETCH_SPLIT_SUCCESS';
@@ -69,7 +70,7 @@ const fetchSplit = (user) => {
       type: FETCH_SPLIT,
     });
 
-    Split.load("wgranger-test/anti-slavery-testing").then((splits) => {
+    Split.load(config.projectSlug).then((splits) => {
       let variant = VARIANT_TYPES.INDIVIDUAL;
 
       const split = splits && splits['classifier.collaborative'];


### PR DESCRIPTION
Since we are beginning seven-ten testing on production, we needed to update the split duck to find the correct slug depending on the environment.