### PR TITLE
User Caesar Production Host

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -25,6 +25,7 @@ const baseConfig = {
     panoptesAppId: '974cc8da2448bac692703f0b364a6b41a7662d91a5a3a1acb064eb703a01e6df', // ASM on Staging
     zooniverseLinks: {
       host: 'https://master.pfe-preview.zooniverse.org/',
+      caesarHost: 'https://caesar-staging.zooniverse.org/graphql',
       projectId: '1764',
       projectSlug: 'wgranger-test/anti-slavery-testing',
       workflowId: '3017'
@@ -34,6 +35,7 @@ const baseConfig = {
     panoptesAppId: '064a5a32a9d2d389eeb876a8b7cb0fbe596fd80d7a040566f14965446d34c541',  //Anti-Slavery Manuscripts
     zooniverseLinks: {
       host: 'https://www.zooniverse.org/',
+      caesarHost: 'https://caesar.zooniverse.org/graphql',
       projectId: '4973',
       projectSlug: 'bostonpubliclibrary/anti-slavery-manuscripts',
       workflowId: '5329'

--- a/src/ducks/previousAnnotations.js
+++ b/src/ducks/previousAnnotations.js
@@ -8,11 +8,6 @@ const initialState = {
   selectedPreviousAnnotation: null
 };
 
-const CAESAR_HOST = 'https://caesar-staging.zooniverse.org/graphql';
-console.log(CAESAR_HOST);
-console.log(config.caesarHost);
-console.log(process.env);
-
 const RESET_PREVIOUS_ANNOTATIONS = 'RESET_PREVIOUS_ANNOTATIONS';
 const FETCH_ANNOTATIONS = 'FETCH_ANNOTATIONS';
 const UPDATE_FRAME ='UPDATE_FRAME';

--- a/src/ducks/previousAnnotations.js
+++ b/src/ducks/previousAnnotations.js
@@ -9,6 +9,9 @@ const initialState = {
 };
 
 const CAESAR_HOST = 'https://caesar-staging.zooniverse.org/graphql';
+console.log(CAESAR_HOST);
+console.log(config.caesarHost);
+console.log(process.env);
 
 const RESET_PREVIOUS_ANNOTATIONS = 'RESET_PREVIOUS_ANNOTATIONS';
 const FETCH_ANNOTATIONS = 'FETCH_ANNOTATIONS';
@@ -20,7 +23,7 @@ const previousAnnotationsReducer = (state = initialState, action) => {
   switch (action.type) {
     case RESET_PREVIOUS_ANNOTATIONS:
       return initialState;
-      
+
     case FETCH_ANNOTATIONS:
       return Object.assign({}, state, {
         data: action.data,
@@ -83,7 +86,7 @@ const resetPreviousAnnotations = () => {
 
 const fetchAnnotations = (subject) => {
   if (!subject) return () => {};
-  
+
   const query = `{
     workflow(id: ${config.zooniverseLinks.workflowId}) {
       reductions(subjectId: ${subject.id}) {
@@ -93,7 +96,7 @@ const fetchAnnotations = (subject) => {
   }`;
 
   return (dispatch, getState) => {
-    request(CAESAR_HOST, query).then((data) => {
+    request(config.zooniverseLinks.caesarHost, query).then((data) => {
       const frame = getState().subjectViewer.frame;
       const reductions = data.workflow.reductions;
       const marks = constructAnnotations(reductions, frame);


### PR DESCRIPTION
This PR adds the correct Caesar production host depending on environment. Error handling and a status state has also been added while fetching previous annotations.

Note: I'm still getting a 404 with new subjects that have no previous annotations attached. Still to be confirmed that is the expected response from the backend.