### PR TITLE
Show Gray Lines on Individual Split

### DIFF
--- a/src/components/AnnotationsPane.jsx
+++ b/src/components/AnnotationsPane.jsx
@@ -15,6 +15,7 @@ import { Utility } from '../lib/Utility';
 import { connect } from 'react-redux';
 import { VisibilitySplit } from 'seven-ten';
 import PendingAnnotation from './PendingAnnotation';
+import { VARIANT_TYPES } from '../ducks/splits';
 
 class AnnotationsPane extends React.Component {
   constructor(props) {
@@ -131,7 +132,6 @@ class AnnotationsPane extends React.Component {
   }
 
   renderPreviousAnnotations() {
-    if (!this.props.previousAnnotations || !this.props.splits) return null;
     return this.renderAnnotations(this.props.previousAnnotations, true);
   }
 
@@ -153,6 +153,12 @@ class AnnotationsPane extends React.Component {
     if (!this.props.showPreviousMarks) return null;
 
     const annotationPrefix = 'ANNOTATION_';
+
+    if (previousAnnotations && this.props.variant === VARIANT_TYPES.INDIVIDUAL) {
+      annotations = annotations.filter((annotation) => {
+        return annotation.consensusReached;
+      });
+    }
 
     return annotations.map((annotation, index) => {
       if (annotation.hasCollaborated === true) { return null; }
@@ -228,7 +234,7 @@ class AnnotationsPane extends React.Component {
 
       if (previousAnnotations && this.props.adminOverride) { return renderedMarks; }
 
-      if (this.props.splits && previousAnnotations) {
+      if (this.props.variant === VARIANT_TYPES.COLLABORATIVE && previousAnnotations) {
         return (
           <VisibilitySplit key={annotationPrefix + index} splits={this.props.splits} splitKey={'classifier.collaborative'} elementKey={'div'}>
             {renderedMarks}
@@ -276,7 +282,8 @@ AnnotationsPane.propTypes = {
   }),
   selectedAnnotationIndex: PropTypes.number,
   showPreviousMarks: PropTypes.bool,
-  splits: PropTypes.object
+  splits: PropTypes.object,
+  variant: PropTypes.string
 };
 
 AnnotationsPane.defaultProps = {
@@ -299,7 +306,8 @@ AnnotationsPane.defaultProps = {
   },
   selectedAnnotationIndex: 0,
   showPreviousMarks: true,
-  splits: null
+  splits: null,
+  variant: VARIANT_TYPES.INDIVIDUAL
 };
 
 const mapStateToProps = (state) => {
@@ -308,7 +316,8 @@ const mapStateToProps = (state) => {
     frame: state.subjectViewer.frame,
     selectedAnnotation: state.annotations.selectedAnnotation,
     selectedAnnotationIndex: state.annotations.selectedAnnotationIndex,
-    splits: state.splits.data
+    splits: state.splits.data,
+    variant: state.splits.variant
   };
 };
 

--- a/src/components/AnnotationsPane.jsx
+++ b/src/components/AnnotationsPane.jsx
@@ -16,6 +16,7 @@ import { connect } from 'react-redux';
 import { VisibilitySplit } from 'seven-ten';
 import PendingAnnotation from './PendingAnnotation';
 import { VARIANT_TYPES } from '../ducks/splits';
+import { MARKS_STATE } from '../ducks/subject-viewer';
 
 class AnnotationsPane extends React.Component {
   constructor(props) {
@@ -42,8 +43,14 @@ class AnnotationsPane extends React.Component {
             mouseInViewer={this.props.mouseInViewer}
           />
         )}
-        {this.renderPreviousAnnotations()}
-        {this.renderUserAnnotations()}
+        {this.props.shownMarks === MARKS_STATE.ALL && (
+          this.renderPreviousAnnotations()
+        )}
+
+        {this.props.shownMarks !== MARKS_STATE.NONE && (
+          this.renderUserAnnotations()
+        )}
+        
         {this.renderAnnotationInProgress()}
       </g>
     );
@@ -150,7 +157,6 @@ class AnnotationsPane extends React.Component {
 
   renderAnnotations(annotations, previousAnnotations = false) {
     if (!annotations) return null;
-    if (!this.props.showPreviousMarks) return null;
 
     const annotationPrefix = 'ANNOTATION_';
 
@@ -281,7 +287,7 @@ AnnotationsPane.propTypes = {
     previousAnnotation: PropTypes.bool
   }),
   selectedAnnotationIndex: PropTypes.number,
-  showPreviousMarks: PropTypes.bool,
+  shownMarks: PropTypes.number,
   splits: PropTypes.object,
   variant: PropTypes.string
 };
@@ -305,7 +311,7 @@ AnnotationsPane.defaultProps = {
     previousAnnotation: false
   },
   selectedAnnotationIndex: 0,
-  showPreviousMarks: true,
+  shownMarks: 0,
   splits: null,
   variant: VARIANT_TYPES.INDIVIDUAL
 };
@@ -316,6 +322,7 @@ const mapStateToProps = (state) => {
     frame: state.subjectViewer.frame,
     selectedAnnotation: state.annotations.selectedAnnotation,
     selectedAnnotationIndex: state.annotations.selectedAnnotationIndex,
+    shownMarks: state.subjectViewer.shownMarks,
     splits: state.splits.data,
     variant: state.splits.variant
   };

--- a/src/containers/ClassifierContainer.jsx
+++ b/src/containers/ClassifierContainer.jsx
@@ -8,7 +8,7 @@ import { config } from '../config';
 import {
   setRotation, setContrast, resetView,
   togglePreviousMarks, setViewerState,
-  SUBJECTVIEWER_STATE,
+  MARKS_STATE, SUBJECTVIEWER_STATE,
 } from '../ducks/subject-viewer';
 
 import { fetchGuide, GUIDE_STATUS } from '../ducks/field-guide';
@@ -90,6 +90,8 @@ class ClassifierContainer extends React.Component {
 
   render() {
     const isAdmin = this.props.user && this.props.user.admin;
+    const shownMarksClass = (MARKS_STATE.ALL === this.props.shownMarks) ? "fa fa-eye" :
+      (MARKS_STATE.USER === this.props.shownMarks) ? "fa fa-eye-slash" : "fa fa-eye-slash grey";
 
     return (
       <main className="app-content classifier-page flex-row">
@@ -163,7 +165,7 @@ class ClassifierContainer extends React.Component {
 
             <button className="flat-button block" onClick={this.togglePreviousMarks}>
               <span className="classifier-toolbar__icon">
-                <i className="fa fa-eye" />
+                <i className={shownMarksClass} />
               </span>
               <span>Toggle Prev. Marks</span>
             </button>
@@ -310,6 +312,7 @@ ClassifierContainer.propTypes = {
   }),
   rotation: PropTypes.number,
   scaling: PropTypes.number,
+  shownMarks: PropTypes.number,
   tutorial: PropTypes.shape({
     steps: PropTypes.array
   }),
@@ -332,6 +335,7 @@ ClassifierContainer.defaultProps = {
   project: null,
   rotation: 0,
   scaling: 1,
+  shownMarks: 0,
   tutorial: null,
   tutorialStatus: TUTORIAL_STATUS.IDLE,
   workflow: null,
@@ -357,6 +361,7 @@ const mapStateToProps = (state, ownProps) => {
     project: state.project.data,
     rotation: state.subjectViewer.rotation,
     scaling: state.subjectViewer.scaling,
+    shownMarks: state.subjectViewer.shownMarks,
     splits: state.splits.splits,
     tutorial: state.tutorial.data,
     tutorialStatus: state.tutorial.status,

--- a/src/containers/SubjectViewer.jsx
+++ b/src/containers/SubjectViewer.jsx
@@ -145,7 +145,6 @@ class SubjectViewer extends React.Component {
               onCompleteAnnotation={this.onCompleteAnnotation}
               onSelectAnnotation={this.onSelectAnnotation}
               previousAnnotations={this.props.previousAnnotations}
-              showPreviousMarks={this.props.showPreviousMarks}
             />
           </g>
           {(!DEV_MODE) ? null :
@@ -502,7 +501,6 @@ SubjectViewer.propTypes = {
       })),
     })
   ),
-  showPreviousMarks: PropTypes.bool,
   selectedAnnotation: PropTypes.shape({
     text: PropTypes.string,
     points: PropTypes.arrayOf(PropTypes.shape({
@@ -539,7 +537,6 @@ SubjectViewer.defaultProps = {
   annotationsStatus: ANNOTATION_STATUS.IDLE,
   annotationInProgress: null,
   annotations: [],
-  showPreviousMarks: true,
   splits: null,
   user: null
 };
@@ -568,7 +565,6 @@ const mapStateToProps = (state, ownProps) => {  //Listens for changes in the Red
     annotationsStatus: anno.status,
     annotationInProgress: anno.annotationInProgress,
     annotations: anno.annotations,
-    showPreviousMarks: sv.showPreviousMarks,
     selectedAnnotation: state.annotations.selectedAnnotation,
     splits: state.splits.data,
     user: state.login.user

--- a/src/ducks/subject-viewer.js
+++ b/src/ducks/subject-viewer.js
@@ -31,7 +31,7 @@ const initialState = {
   frame: 0,
   rotation: 0,
   scaling: 1,
-  shownMarks: 0,
+  shownMarks: MARKS_STATE.ALL,
   translationX: 0,
   translationY: 0,
 
@@ -195,8 +195,9 @@ const togglePreviousMarks = () => {
     const variant = getState().splits.variant;
     const consensusAnnotation = annotations.some(annotation => { return annotation.consensusReached; })
     const previousAnnotationsPresent = consensusAnnotation || (annotations.length && variant === VARIANT_TYPES.COLLABORATIVE);
+    const numberOfStates = Object.keys(MARKS_STATE).length;
 
-    let shownMarks = (getState().subjectViewer.shownMarks + 1) % 3;
+    let shownMarks = (getState().subjectViewer.shownMarks + 1) % numberOfStates;
     if (!previousAnnotationsPresent && shownMarks === MARKS_STATE.USER) {
       shownMarks = MARKS_STATE.NONE;
     }

--- a/src/ducks/subject-viewer.js
+++ b/src/ducks/subject-viewer.js
@@ -6,6 +6,8 @@ This duck (collection of redux actions + reducers) is used to control the view
 options/settings of the SubjectViewer component.
 
  */
+import { CONSENSUS_SCORE } from '../config';
+import { VARIANT_TYPES } from '../ducks/splits';
 
 //Misc Constants
 const SUBJECTVIEWER_STATE = {
@@ -16,6 +18,12 @@ const SUBJECTVIEWER_STATE = {
 const MIN_SCALING = 0.1;
 const MAX_SCALING = 10;
 
+const MARKS_STATE = {
+  ALL: 0,
+  USER: 1,
+  NONE: 2,
+};
+
 //Initial State
 const initialState = {
   //Image transformations
@@ -23,7 +31,7 @@ const initialState = {
   frame: 0,
   rotation: 0,
   scaling: 1,
-  showPreviousMarks: true,
+  shownMarks: 0,
   translationX: 0,
   translationY: 0,
 
@@ -68,10 +76,8 @@ const subjectViewerReducer = (state = initialState, action) => {
       });
 
     case TOGGLE_MARKS:
-      const visibleMarks = !state.showPreviousMarks;
-
       return Object.assign({}, state, {
-        showPreviousMarks: visibleMarks
+        shownMarks: action.shownMarks
       });
 
     case SET_SCALING:
@@ -184,9 +190,20 @@ const resetView = () => {
 };
 
 const togglePreviousMarks = () => {
-  return (dispatch) => {
+  return (dispatch, getState) => {
+    const annotations = getState().previousAnnotations.marks;
+    const variant = getState().splits.variant;
+    const consensusAnnotation = annotations.some(annotation => { return annotation.consensusReached; })
+    const previousAnnotationsPresent = consensusAnnotation || (annotations.length && variant === VARIANT_TYPES.COLLABORATIVE);
+
+    let shownMarks = (getState().subjectViewer.shownMarks + 1) % 3;
+    if (!previousAnnotationsPresent && shownMarks === MARKS_STATE.USER) {
+      shownMarks = MARKS_STATE.NONE;
+    }
+
     dispatch({
       type: TOGGLE_MARKS,
+      shownMarks
     });
   }
 };
@@ -244,5 +261,6 @@ export {
   togglePreviousMarks,
   updateViewerSize,
   updateImageSize,
+  MARKS_STATE,
   SUBJECTVIEWER_STATE,
 };

--- a/src/styles/components/classifier-page.styl
+++ b/src/styles/components/classifier-page.styl
@@ -84,6 +84,9 @@
         text-align: center
         width: 1.2rem
 
+        .grey
+          color: $light-grey
+
 .navigator-viewer
   margin-bottom: 1em
 


### PR DESCRIPTION
This PR addresses two issues:

1) Show gray consensus lines for both collaborative *and* individual splits. Closes #146 
2) Adjust the toggle state for "toggle prev. marks." Now, the user may toggle between seeing all/previous annotations, seeing only user annotations, seeing only current annotation. *Note:* a check was made to only toggle between all marks and no marks if no previous annotations are present. 