### PR TITLE
Add Accessibility to Focus Items

### DIFF
--- a/src/components/ProjectHeader.jsx
+++ b/src/components/ProjectHeader.jsx
@@ -51,7 +51,7 @@ class ProjectHeader extends React.Component {
             className="project-header__link"
             to="/about"
           >
-            <button onClick={this.aboutClick}>
+            <button onClick={this.aboutClick} tabIndex="-1">
               About
             </button>
           </Link>
@@ -67,7 +67,7 @@ class ProjectHeader extends React.Component {
             href={config.zooniverseLinks.host + 'projects/' + config.zooniverseLinks.projectSlug + '/talk'}
             target="_blank"
           >
-            <button onClick={this.talkClick}>
+            <button onClick={this.talkClick} tabIndex="-1">
               Talk
             </button>
           </a>

--- a/src/components/SubmitClassificationForm.jsx
+++ b/src/components/SubmitClassificationForm.jsx
@@ -15,7 +15,7 @@ import {
 class SubmitClassificationForm extends React.Component {
   constructor(props) {
     super(props);
-  
+
     this.completeClassification = this.completeClassification.bind(this);
     this.submitClassificationAndRedirect = this.submitClassificationAndRedirect.bind(this);
   }
@@ -24,7 +24,7 @@ class SubmitClassificationForm extends React.Component {
 
   render() {
     let numberOfAnswersMatchQuestions = true;
-    
+
     if (this.props.subjectCompletionAnswers && this.props.workflowData) {
       const numberOfQuestions = Object.keys(this.props.workflowData.tasks)
       .map((taskId) => {
@@ -40,27 +40,27 @@ class SubmitClassificationForm extends React.Component {
       const numberOfAnswers = Object.keys(this.props.subjectCompletionAnswers).length;
       numberOfAnswersMatchQuestions = numberOfQuestions === numberOfAnswers;
     }
-    
+
     return (
       <div className="submit-classification-form">
         <h2>Submit Classification</h2>
         {this.renderSubjectCompletionQuestions()}
         <div className="action-buttons">
-          <button href="#" className="white-green button" onClick={() => { this.props.closePopup && this.props.closePopup(); }}>Cancel</button>
-          <button href="#" disabled={!numberOfAnswersMatchQuestions} className={(numberOfAnswersMatchQuestions) ? 'white-green button' : 'disabled button'} onClick={this.completeClassification}>Done</button>
-          <button href="#" disabled={!numberOfAnswersMatchQuestions} className={(numberOfAnswersMatchQuestions) ? 'green button' : 'disabled button'} onClick={this.submitClassificationAndRedirect}>
+          <button className="white-green button" onClick={() => { this.props.closePopup && this.props.closePopup(); }}>Cancel</button>
+          <button disabled={!numberOfAnswersMatchQuestions} className={(numberOfAnswersMatchQuestions) ? 'white-green button' : 'disabled button'} onClick={this.completeClassification}>Done</button>
+          <button disabled={!numberOfAnswersMatchQuestions} className={(numberOfAnswersMatchQuestions) ? 'green button' : 'disabled button'} onClick={this.submitClassificationAndRedirect}>
             Done &amp; Talk
           </button>
         </div>
       </div>
     );
   }
-  
+
   completeClassification() {
     if (this.context.googleLogger) {
       this.context.googleLogger.logEvent({ type: 'complete-classification' });
     }
-    
+
     this.props.dispatch(submitClassification())
     this.props.closePopup && this.props.closePopup();
   }
@@ -69,12 +69,12 @@ class SubmitClassificationForm extends React.Component {
     if (this.context.googleLogger) {
       this.context.googleLogger.logEvent({ type: 'complete-classification-and-talk' });
     }
-    
+
     this.props.dispatch(submitClassification())
     this.props.closePopup && this.props.closePopup();
     window.open(config.zooniverseLinks.host + 'projects/' + config.zooniverseLinks.projectSlug + '/talk', '_blank');
   }
-  
+
   /*  This function renders all the non-transcription Panoptes tasks (i.e.
       questions) provided by the workflow.
       A special note on the way that this Panoptes transcription project is
@@ -86,7 +86,7 @@ class SubmitClassificationForm extends React.Component {
    */
   renderSubjectCompletionQuestions() {
     if (!this.props.workflowData) return null;
-    
+
     //Display all question tasks, except for the first task.
     const tasks = (this.props.workflowData.tasks)
       ? Object.keys(this.props.workflowData.tasks)
@@ -100,7 +100,7 @@ class SubmitClassificationForm extends React.Component {
           return isAQuestionTask(task, this.props.workflowData);
         })
       : [];
-    
+
     return (
       <div className="tasks body-copy">
         {tasks.map((task, taskIndex) =>{

--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -26,6 +26,7 @@ class Timeline extends React.Component {
     this.renderEvent = this.renderEvent.bind(this);
     this.renderText = this.renderText.bind(this);
     this.renderGroups = this.renderGroups.bind(this);
+    this.handleOnBlur = this.handleOnBlur.bind(this);
 
     this.state = {
       activeEvent: null,
@@ -72,13 +73,23 @@ class Timeline extends React.Component {
     this.setState({ clickIndex: null })
   }
 
+  handleKeyPress(data, e) {
+    if (e.keyCode === 13) {
+      this.handleMouseEnter(data);
+    }
+  }
+
+  handleOnBlur() {
+    this.setState({ activeEvent: null });
+  }
+
   renderEvent(event, i) {
     const position = this.dateFinder(event.year);
     const clicked = this.state.clickIndex == i ? true : false;
     const data = { x: position.placement, event: event, i };
 
     return (
-      <g key={i} transform={`translate(${position.placement}, ${60})`} onMouseDown={this.handleMouseEnter.bind(this, data)} >
+      <g key={i} tabIndex={0} onKeyUp={this.handleKeyPress.bind(this, data)} onBlur={this.handleOnBlur} transform={`translate(${position.placement}, ${60})`} onMouseDown={this.handleMouseEnter.bind(this, data)} >
         <line
           ref={(c) => {this.test = c;} }
           className="event-line"

--- a/src/containers/ClassifierContainer.jsx
+++ b/src/containers/ClassifierContainer.jsx
@@ -111,17 +111,17 @@ class ClassifierContainer extends React.Component {
           </div>
           <div className="help-buttons">
             {this.props.tutorial && this.props.tutorialStatus === TUTORIAL_STATUS.READY && (
-              <button href="#" className="white-red button" onClick={this.showTutorial}>Tutorial</button>
+              <button className="white-red button" onClick={this.showTutorial}>Tutorial</button>
             )}
             {this.props.guide && this.props.guideStatus === GUIDE_STATUS.READY && (
-              <button href="#" className="white-red button" onClick={this.toggleFieldGuide}>Field Guide</button>
+              <button className="white-red button" onClick={this.toggleFieldGuide}>Field Guide</button>
             )}
             {/*TEMPORARILY REMOVED: CRIBSHEET
-            <button href="#" className="white-red button">Your Crib Sheet</button>*/}
+            <button className="white-red button">Your Crib Sheet</button>*/}
             <img className="divider" role="presentation" src={Divider} />
 
 
-            <button href="#" className="white-green button" onClick={this.prepareSubmitClassificationForm}>Finish</button>
+            <button className="white-green button" onClick={this.prepareSubmitClassificationForm}>Finish</button>
           </div>
         </section>
 

--- a/src/styles/components/zoom-tools.styl
+++ b/src/styles/components/zoom-tools.styl
@@ -14,6 +14,3 @@
 
   button
     justify-content: center
-
-    &:focus
-      outline: 0


### PR DESCRIPTION
There were a couple issues with focus that arose from internal testing. The major issue with focus is finding a way for the subject viewer to interact with the keyboard, which will require more attention.

For now, this PR accomplishes three items:
1) Remove double focus or project header items ("About" and "Talk")
2) Add focus styling to zoom buttons
3) Add focus and interactivity to SVG items on the timeline
4) Remove `href="#"` from buttons