### PR TITLE
[RFC] Only Use Beta Subject Sets

### DIFF
--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -94,7 +94,9 @@ class Home extends React.Component {
           </div>
 
           <Link to="/classify">Start Transcribing</Link>
-{/*       NOTE: Hide Subject Set Selection During Beta Launch.
+          {/*
+          //BETA_ONLY
+          NOTE: Hide Subject Set Selection During Beta Launch.
           <h3 className="transcribe">
             <Link onClick={this.setSubjectSet.bind(this, null)} to="/classify">Transcribe Random &#8608;</Link>
           </h3>
@@ -104,7 +106,8 @@ class Home extends React.Component {
           </span>
           <div className="home-page__topic-select flex-row">
             {this.renderTopics()}
-          </div> */}
+          </div>
+          */}
         </div>
         <div id="home-logos" className="home-page__logos flex-row">
           <a href="https://www.zooniverse.org">

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -93,6 +93,8 @@ class Home extends React.Component {
             {this.props.project && this.props.project.description}
           </div>
 
+          <Link to="/classify">Start Transcribing</Link>
+{/*       NOTE: Hide Subject Set Selection During Beta Launch.
           <h3 className="transcribe">
             <Link onClick={this.setSubjectSet.bind(this, null)} to="/classify">Transcribe Random &#8608;</Link>
           </h3>
@@ -102,7 +104,7 @@ class Home extends React.Component {
           </span>
           <div className="home-page__topic-select flex-row">
             {this.renderTopics()}
-          </div>
+          </div> */}
         </div>
         <div id="home-logos" className="home-page__logos flex-row">
           <a href="https://www.zooniverse.org">

--- a/src/config.js
+++ b/src/config.js
@@ -28,7 +28,8 @@ const baseConfig = {
       caesarHost: 'https://caesar-staging.zooniverse.org/graphql',
       projectId: '1764',
       projectSlug: 'wgranger-test/anti-slavery-testing',
-      workflowId: '3017'
+      workflowId: '3017',
+      betaSet: '4375'
     },
   },
   production: {
@@ -38,7 +39,8 @@ const baseConfig = {
       caesarHost: 'https://caesar.zooniverse.org/graphql',
       projectId: '4973',
       projectSlug: 'bostonpubliclibrary/anti-slavery-manuscripts',
-      workflowId: '5329'
+      workflowId: '5329',
+      betaSet: '16228'
     },
   }
 };

--- a/src/config.js
+++ b/src/config.js
@@ -29,8 +29,8 @@ const baseConfig = {
       projectId: '1764',
       projectSlug: 'wgranger-test/anti-slavery-testing',
       workflowId: '3017',
-      betaSet: '4375',
       collabWorkflowId: '3085',
+      betaSubjectSet: '4375',  //BETA_ONLY
     },
   },
   production: {
@@ -41,8 +41,8 @@ const baseConfig = {
       projectId: '4973',
       projectSlug: 'bostonpubliclibrary/anti-slavery-manuscripts',
       workflowId: '5329',
-      betaSet: '16228',
       collabWorkflowId: '5339',
+      betaSubjectSet: '16228',  //BETA_ONLY
     },
   }
 };
@@ -63,7 +63,6 @@ const baseSubjectSets = {
     { title: '1870-1900', id: '15526' }
   ]
 };
-
 
 baseConfig.staging = baseConfig.development;  //staging === development, as far as we're concerned.
 baseSubjectSets.staging = baseSubjectSets.development;

--- a/src/ducks/subject.js
+++ b/src/ducks/subject.js
@@ -156,25 +156,37 @@ const fetchSubject = (id = config.zooniverseLinks.workflowId) => {
     dispatch({
       type: FETCH_SUBJECT,
     });
+    
+    //BETA_ONLY
+    //----------------
+    const subjectQuery = {
+      workflow_id: id,
+      subject_set_id: config.zooniverseLinks.betaSubjectSet,
+    };
+    //----------------
 
-    // NOTE: Remove Subject Selection While in Beta
-    // let randomSubjectSet;
-    // const workflow = getState().workflow.data;
-    // if (workflow && workflow.links.subject_sets.length) {
-    //   const linkedSets = workflow.links.subject_sets;
-    //   randomSubjectSet = linkedSets[Math.floor(Math.random()*linkedSets.length)];
-    // } else {
-    //   randomSubjectSet = subjectSets[Math.floor(Math.random()*subjectSets.length)].id;
-    // }
+    //Removed for //BETA_ONLY
+    //----------------
+    /*
+    let randomSubjectSet;
+    const workflow = getState().workflow.data;
+    if (workflow && workflow.links.subject_sets.length) {
+      const linkedSets = workflow.links.subject_sets;
+      randomSubjectSet = linkedSets[Math.floor(Math.random()*linkedSets.length)];
+    } else {
+      randomSubjectSet = subjectSets[Math.floor(Math.random()*subjectSets.length)].id;
+    }
 
     const subjectQuery = {
       workflow_id: id,
-      subject_set_id: config.zooniverseLinks.betaSet
+      subject_set_id: randomSubjectSet
     };
 
-    // if (getState().subject.subjectSet) {
-    //   subjectQuery.subject_set_id = getState().subject.subjectSet;
-    // }
+    if (getState().subject.subjectSet) {
+      subjectQuery.subject_set_id = getState().subject.subjectSet;
+    }
+    */
+    //----------------
 
     const fetchQueue = () => {
       apiClient.type('subjects/queued').get(subjectQuery)

--- a/src/ducks/subject.js
+++ b/src/ducks/subject.js
@@ -157,23 +157,24 @@ const fetchSubject = (id = config.zooniverseLinks.workflowId) => {
       type: FETCH_SUBJECT,
     });
 
-    let randomSubjectSet;
-    const workflow = getState().workflow.data;
-    if (workflow && workflow.links.subject_sets.length) {
-      const linkedSets = workflow.links.subject_sets;
-      randomSubjectSet = linkedSets[Math.floor(Math.random()*linkedSets.length)];
-    } else {
-      randomSubjectSet = subjectSets[Math.floor(Math.random()*subjectSets.length)].id;
-    }
+    // NOTE: Remove Subject Selection While in Beta
+    // let randomSubjectSet;
+    // const workflow = getState().workflow.data;
+    // if (workflow && workflow.links.subject_sets.length) {
+    //   const linkedSets = workflow.links.subject_sets;
+    //   randomSubjectSet = linkedSets[Math.floor(Math.random()*linkedSets.length)];
+    // } else {
+    //   randomSubjectSet = subjectSets[Math.floor(Math.random()*subjectSets.length)].id;
+    // }
 
     const subjectQuery = {
       workflow_id: id,
-      subject_set_id: randomSubjectSet
+      subject_set_id: config.zooniverseLinks.betaSet
     };
 
-    if (getState().subject.subjectSet) {
-      subjectQuery.subject_set_id = getState().subject.subjectSet;
-    }
+    // if (getState().subject.subjectSet) {
+    //   subjectQuery.subject_set_id = getState().subject.subjectSet;
+    // }
 
     const fetchQueue = () => {
       apiClient.type('subjects/queued').get(subjectQuery)

--- a/src/styles/components/home-page.styl
+++ b/src/styles/components/home-page.styl
@@ -28,6 +28,15 @@
       @media(max-width: 500px)
         font-size: 3em
 
+    a
+      @extend .secondary-head-link
+      border-bottom: 2px solid transparent
+      font-size: 0.85em
+      margin: auto
+
+      &:hover, &:focus
+        border-bottom: 2px solid $eggplant
+
   &__progress-bar
     background: $light-eggplant
     display: flex


### PR DESCRIPTION
This is necessary for beta launch. Instead of giving users the option to choose which subject set they draw from, the beta subject set will be the only one used. This should be removed eventually for full launch.

Currently RFC because there might be the same issue with the `subject_set_id` query failing to pull subjects from the correct set, but I'd like another set of eyes on the code to confirm.