### PR TITLE
Cancelling a new Annotation now deletes it

### DIFF
--- a/src/components/SelectedAnnotation.jsx
+++ b/src/components/SelectedAnnotation.jsx
@@ -235,7 +235,23 @@ class SelectedAnnotation extends React.Component {
   }
 
   cancelAnnotation() {
-    if (this.props.onClose) { this.props.onClose() };
+    //If the initial Annotation text is empty, it means this Annotation was
+    //_just created._ If the user Cancels a _just created_ Annotation, it
+    //implies that the user didn't create the Annotation line correctly and
+    //wants to try again. More importantly, this prevents users from using
+    //'Cancel' to submit new Annotations with no text.
+    //This check ignores the current value of this.inputText as it has no
+    //bearing to the logic.
+    const initialAnnotationText =
+      (this.props.selectedAnnotation && this.props.selectedAnnotation.details &&
+       this.props.selectedAnnotation.details[0] && this.props.selectedAnnotation.details[0].value)
+      ? this.props.selectedAnnotation.details[0].value : '';
+
+    if (initialAnnotationText.trim().length === 0) {
+      this.deleteAnnotation();  //Cancel this action and delete the newly created Annotation.
+    } else {
+      if (this.props.onClose) { this.props.onClose() };  //Cancel this action; make no updates to the existing (and valid) Annotation.
+    }
 
     if (this.context.googleLogger) {
       this.context.googleLogger.logEvent({ type: 'cancel-transcription' });

--- a/src/components/SelectedAnnotation.jsx
+++ b/src/components/SelectedAnnotation.jsx
@@ -235,22 +235,16 @@ class SelectedAnnotation extends React.Component {
   }
 
   cancelAnnotation() {
-    //If the initial Annotation text is empty, it means this Annotation was
-    //_just created._ If the user Cancels a _just created_ Annotation, it
-    //implies that the user didn't create the Annotation line correctly and
-    //wants to try again. More importantly, this prevents users from using
-    //'Cancel' to submit new Annotations with no text.
-    //This check ignores the current value of this.inputText as it has no
-    //bearing to the logic.
+    //Cancelling a new Annotation (i.e. it starts off with empty text) should also delete it.
     const initialAnnotationText =
       (this.props.selectedAnnotation && this.props.selectedAnnotation.details &&
        this.props.selectedAnnotation.details[0] && this.props.selectedAnnotation.details[0].value)
       ? this.props.selectedAnnotation.details[0].value : '';
 
     if (initialAnnotationText.trim().length === 0) {
-      this.deleteAnnotation();  //Cancel this action and delete the newly created Annotation.
+      this.deleteAnnotation();  //Cancel this action and delete this newly created Annotation.
     } else {
-      if (this.props.onClose) { this.props.onClose() };  //Cancel this action; make no updates to the existing (and valid) Annotation.
+      if (this.props.onClose) { this.props.onClose() };  //Cancel this action and make no updates to the existing (and valid) Annotation.
     }
 
     if (this.context.googleLogger) {

--- a/src/components/SelectedAnnotation.jsx
+++ b/src/components/SelectedAnnotation.jsx
@@ -187,7 +187,7 @@ class SelectedAnnotation extends React.Component {
         <div className={ENABLE_DRAG} ref={(c) => {this.dialog = c}}>
           <div>
             <h2>Transcribe</h2>
-            <button className="close-button" onClick={this.props.onClose}>X</button>
+            <button className="close-button" onClick={this.cancelAnnotation}>X</button>
           </div>
           <span>
             Enter the words you marked in the order you marked them. Open the


### PR DESCRIPTION
## PR Overview
- With this PR, when a user creates a new Annotation and then proceeds to Cancel it (or clicks on the X to close the window) on the Transcription popup, that new Annotation is _deleted._
  - For our purposes, a 'new Annotation' can be implied when the selected annotation has zero transcribed text.
  - This prevents users from submitting Annotations with no text, simply by cancelling out of a newly created Annotation (which has no text).
- Clicking Cancel or close on an existing Annotation simply reverts the Annotation to its previous state, (i.e. before the Transcription popup appeared,) as normal.

### Status
Ready for review, @wgranger 