### PR TITLE
Successfully fetching Subjects now properly resets Annotations, Previous Annotations, and Classifications

### DIFF
--- a/src/containers/SubjectViewer.jsx
+++ b/src/containers/SubjectViewer.jsx
@@ -547,7 +547,7 @@ SubjectViewer.defaultProps = {
   annotationInProgress: null,
   annotations: [],
   //--------
-  selectedAnnotations: null,
+  selectedAnnotation: null,
 };
 
 SubjectViewer.contextTypes = {

--- a/src/containers/SubjectViewer.jsx
+++ b/src/containers/SubjectViewer.jsx
@@ -192,10 +192,18 @@ class SubjectViewer extends React.Component {
     //Make sure we monitor visible size of Subject Viewer.
     window.addEventListener('resize', this.updateSize);
     this.updateSize();
-    this.props.dispatch(fetchSubject());  //Fetch the first subject. This will also ensure a clean slate for Annotations, Previous Annotations, and Classifications.
+    
+    //Fetch the first subject, IF no subject has yet been loaded.
+    //Fetching a subject will also ensure a clean slate for Annotations,
+    //Previous Annotations, and Classifications.
+    this.props.dispatch(fetchSubject(
+      undefined,  //JS Quirk: this ensures we're fetching the default value for the 'id' parameter (as defined in fetchSubject())
+      true,  //Initial fetch only, meaning ignore this action call if a Subject is already being fetch/has already been loaded.
+    ));
   }
 
   componentWillReceiveProps(next) {
+    //An annotation was just selected.
     if (!this.props.selectedAnnotation && next.selectedAnnotation) {
       this.setState({
         annotation: <SelectedAnnotation annotation={next.selectedAnnotation} onClose={this.closeAnnotation} />

--- a/src/containers/SubjectViewer.jsx
+++ b/src/containers/SubjectViewer.jsx
@@ -26,7 +26,7 @@ import SVGImage from '../components/SVGImage';
 import AnnotationsPane from '../components/AnnotationsPane';
 import ZoomTools from '../components/ZoomTools';
 import { Utility } from '../lib/Utility';
-import { fetchSubject, setImageMetadata, SUBJECT_STATUS } from '../ducks/subject';
+import { fetchSubject, setImageMetadata } from '../ducks/subject';
 import { getSubjectLocation } from '../lib/get-subject-location';
 import SelectedAnnotation from '../components/SelectedAnnotation';
 
@@ -473,7 +473,6 @@ SubjectViewer.propTypes = {
   currentSubject: PropTypes.shape({
     src: PropTypes.string,
   }),
-  subjectStatus: PropTypes.string,
   //--------
   contrast: PropTypes.bool,
   frame: PropTypes.number,
@@ -524,7 +523,6 @@ SubjectViewer.defaultProps = {
   user: null,
   //-------
   currentSubject: null,
-  subjectStatus: SUBJECT_STATUS.IDLE,
   //-------
   contrast: false,
   frame: 0,
@@ -564,7 +562,6 @@ const mapStateToProps = (state, ownProps) => {  //Listens for changes in the Red
     user: state.login.user,
     //--------
     currentSubject: state.subject.currentSubject,
-    subjectStatus: state.subject.status,
     //--------
     contrast: sv.contrast,
     frame: sv.frame,

--- a/src/containers/SubjectViewer.jsx
+++ b/src/containers/SubjectViewer.jsx
@@ -457,14 +457,18 @@ class SubjectViewer extends React.Component {
 SubjectViewer.propTypes = {
   dispatch: PropTypes.func,
   //--------
+  splits: PropTypes.object,
+  user: PropTypes.shape({
+    id: PropTypes.string
+  }),
+  //--------
   currentSubject: PropTypes.shape({
     src: PropTypes.string,
   }),
+  subjectStatus: PropTypes.string,
+  //--------
   contrast: PropTypes.bool,
-  dispatch: PropTypes.func,
   frame: PropTypes.number,
-  imageSize: PropTypes.object,
-  previousAnnotations: PropTypes.arrayOf(PropTypes.object),
   rotation: PropTypes.number,
   scaling: PropTypes.number,
   translationX: PropTypes.number,
@@ -478,6 +482,8 @@ SubjectViewer.propTypes = {
     width: PropTypes.number,
     height: PropTypes.number,
   }),
+  //--------
+  previousAnnotations: PropTypes.arrayOf(PropTypes.object),
   //--------
   annotationsStatus: PropTypes.string,
   annotationInProgress: PropTypes.shape({
@@ -496,6 +502,7 @@ SubjectViewer.propTypes = {
       })),
     })
   ),
+  //--------
   selectedAnnotation: PropTypes.shape({
     text: PropTypes.string,
     points: PropTypes.arrayOf(PropTypes.shape({
@@ -503,17 +510,16 @@ SubjectViewer.propTypes = {
       y: PropTypes.number,
     })),
   }),
-  splits: PropTypes.object,
-  user: PropTypes.shape({
-    id: PropTypes.string
-  })
 };
 SubjectViewer.defaultProps = {
-  contrast: false,
+  splits: null,
+  user: null,
+  //-------
   currentSubject: null,
+  subjectStatus: SUBJECT_STATUS.IDLE,
+  //-------
+  contrast: false,
   frame: 0,
-  //--------
-  previousAnnotations: [],
   rotation: 0,
   scaling: 1,
   selectedAnnotation: null,
@@ -529,11 +535,13 @@ SubjectViewer.defaultProps = {
     height: 0,
   },
   //--------
+  previousAnnotations: [],
+  //--------
   annotationsStatus: ANNOTATION_STATUS.IDLE,
   annotationInProgress: null,
   annotations: [],
-  splits: null,
-  user: null
+  //--------
+  selectedAnnotations: null,
 };
 
 SubjectViewer.contextTypes = {
@@ -544,11 +552,14 @@ const mapStateToProps = (state, ownProps) => {  //Listens for changes in the Red
   const sv = state.subjectViewer;
   const anno = state.annotations;
   return {
-    currentSubject: state.subject.currentSubject,
-    contrast: sv.contrast,
+    splits: state.splits.data,
+    user: state.login.user,
     //--------
+    currentSubject: state.subject.currentSubject,
+    subjectStatus: state.subject.status,
+    //--------
+    contrast: sv.contrast,
     frame: sv.frame,
-    previousAnnotations: state.previousAnnotations.marks,
     rotation: sv.rotation,
     scaling: sv.scaling,
     translationX: sv.translationX,
@@ -557,12 +568,13 @@ const mapStateToProps = (state, ownProps) => {  //Listens for changes in the Red
     viewerSize: sv.viewerSize,
     imageSize: sv.imageSize,
     //--------
+    previousAnnotations: state.previousAnnotations.marks,
+    //--------
     annotationsStatus: anno.status,
     annotationInProgress: anno.annotationInProgress,
     annotations: anno.annotations,
+    //--------
     selectedAnnotation: state.annotations.selectedAnnotation,
-    splits: state.splits.data,
-    user: state.login.user
   };
 };
 export default connect(mapStateToProps)(SubjectViewer);  //Connects the Component to the Redux Store

--- a/src/containers/SubjectViewer.jsx
+++ b/src/containers/SubjectViewer.jsx
@@ -29,7 +29,6 @@ import { Utility } from '../lib/Utility';
 import { fetchSubject, setImageMetadata, SUBJECT_STATUS } from '../ducks/subject';
 import { getSubjectLocation } from '../lib/get-subject-location';
 import SelectedAnnotation from '../components/SelectedAnnotation';
-import { fetchAnnotations } from '../ducks/previousAnnotations';
 
 import {
   setRotation, setScaling, setTranslation, resetView,
@@ -201,10 +200,6 @@ class SubjectViewer extends React.Component {
       this.setState({
         annotation: <SelectedAnnotation annotation={next.selectedAnnotation} onClose={this.closeAnnotation} />
       });
-    }
-
-    if (this.props.currentSubject !== next.currentSubject) {
-      this.props.dispatch(fetchAnnotations(next.currentSubject));
     }
   }
 

--- a/src/containers/SubjectViewer.jsx
+++ b/src/containers/SubjectViewer.jsx
@@ -193,7 +193,7 @@ class SubjectViewer extends React.Component {
     //Make sure we monitor visible size of Subject Viewer.
     window.addEventListener('resize', this.updateSize);
     this.updateSize();
-    this.props.dispatch(fetchSubject());  //Fetch the first subject.
+    this.props.dispatch(fetchSubject());  //Fetch the first subject. This will also ensure a clean slate for Annotations, Previous Annotations, and Classifications.
   }
 
   componentWillReceiveProps(next) {

--- a/src/ducks/classifications.js
+++ b/src/ducks/classifications.js
@@ -3,7 +3,6 @@ import counterpart from 'counterpart';
 import { getSessionID } from '../lib/get-session-id';
 import { Split } from 'seven-ten';
 
-import { fetchAnnotations } from './previousAnnotations';
 import { fetchSubject } from './subject';
 import { resetView } from './subject-viewer';
 

--- a/src/ducks/classifications.js
+++ b/src/ducks/classifications.js
@@ -3,8 +3,7 @@ import counterpart from 'counterpart';
 import { getSessionID } from '../lib/get-session-id';
 import { Split } from 'seven-ten';
 
-import { resetAnnotations } from './annotations';
-import { resetPreviousAnnotations, fetchAnnotations } from './previousAnnotations';
+import { fetchAnnotations } from './previousAnnotations';
 import { fetchSubject } from './subject';
 import { resetView } from './subject-viewer';
 
@@ -165,9 +164,7 @@ const submitClassification = () => {
 
       //Reset values in preparation for the next Subject.
       dispatch({ type: SUBMIT_CLASSIFICATION_SUCCESS });
-      dispatch(resetAnnotations());
-      dispatch(resetPreviousAnnotations());
-      dispatch(fetchSubject());  //Note: fetching a Subject will also create an empty Classification.
+      dispatch(fetchSubject());  //Note: fetching a Subject will also reset Annotations, reset Previous Annotations, and create an empty Classification.
       dispatch(resetView());
     })
 

--- a/src/ducks/previousAnnotations.js
+++ b/src/ducks/previousAnnotations.js
@@ -2,17 +2,10 @@ import { request } from 'graphql-request';
 import { constructCoordinates, constructText } from '../lib/construct-previous-annotations';
 import { config, CONSENSUS_SCORE } from '../config.js';
 
-const initialState = {
-  data: null,
-  marks: [],
-  selectedPreviousAnnotation: null
-};
-
 const FETCH_ANNOTATIONS = 'FETCH_ANNOTATIONS';
 const FETCH_ANNOTATIONS_SUCCESS = 'FETCH_ANNOTATIONS_SUCCESS';
 const FETCH_ANNOTATIONS_ERROR = 'FETCH_ANNOTATIONS_ERROR';
 
-const RESET_PREVIOUS_ANNOTATIONS = 'RESET_PREVIOUS_ANNOTATIONS';
 const UPDATE_FRAME ='UPDATE_FRAME';
 const UPDATE_PREVIOUS_ANNOTATION = 'UPDATE_PREVIOUS_ANNOTATION';
 const REENABLE_PREVIOUS_ANNOTATION = 'REENABLE_PREVIOUS_ANNOTATION';
@@ -24,13 +17,20 @@ const PREVIOUS_ANNOTATION_STATUS = {
   ERROR: 'previous_annotation_status_error',
 };
 
+const initialState = {
+  data: null,
+  marks: [],
+  selectedPreviousAnnotation: null,
+  status: PREVIOUS_ANNOTATION_STATUS.IDLE,
+};
+
 const previousAnnotationsReducer = (state = initialState, action) => {
   switch (action.type) {
-    case RESET_PREVIOUS_ANNOTATIONS:
-      return initialState;
-
     case FETCH_ANNOTATIONS:
       return Object.assign({}, state, {
+        data: null,  //Reset
+        marks: [],  //Reset
+        selectedPreviousAnnotation: null,  //Reset
         status: PREVIOUS_ANNOTATION_STATUS.FETCHING
       });
 
@@ -94,13 +94,7 @@ const previousAnnotationsReducer = (state = initialState, action) => {
  };
 };
 
-const resetPreviousAnnotations = () => {
-  return (dispatch) => {
-    dispatch({ type: RESET_PREVIOUS_ANNOTATIONS });
-  };
-};
-
-const fetchAnnotations = (subject) => {
+const fetchPreviousAnnotations = (subject) => {
   if (!subject) return () => {};
 
   const query = `{
@@ -193,9 +187,8 @@ const constructAnnotations = (reductions, frame) => {
 export default previousAnnotationsReducer;
 
 export {
-  resetPreviousAnnotations,
   changeFrameData,
-  fetchAnnotations,
+  fetchPreviousAnnotations,
   updatePreviousAnnotation,
   reenablePreviousAnnotation,
 };

--- a/src/ducks/subject.js
+++ b/src/ducks/subject.js
@@ -203,7 +203,7 @@ const fetchSubject = (id = config.zooniverseLinks.workflowId) => {
             favorite: currentSubject.favorite || false,
           });
 
-          prepareForNewSubject(dispatch);
+          prepareForNewSubject(dispatch, currentSubject);
         })
         .catch((err) => {
           console.error(err);
@@ -223,7 +223,7 @@ const fetchSubject = (id = config.zooniverseLinks.workflowId) => {
         favorite: currentSubject.favorite || false,
       });
 
-      prepareForNewSubject(dispatch);
+      prepareForNewSubject(dispatch, currentSubject);
     }
   };
 };
@@ -232,9 +232,9 @@ const fetchSubject = (id = config.zooniverseLinks.workflowId) => {
     existing Annotations, (reset then) fetch the corresponding Previous
     Annotations, create a new Classification, and set the viewer back to page 1.
  */
-const prepareForNewSubject = (dispatch) => {
+const prepareForNewSubject = (dispatch, subject) => {
   dispatch(resetAnnotations());
-  dispatch(fetchPreviousAnnotations());
+  dispatch(fetchPreviousAnnotations(subject));
   dispatch(createClassification());
   dispatch(changeFrame(0));
 };

--- a/src/ducks/subject.js
+++ b/src/ducks/subject.js
@@ -153,8 +153,14 @@ const selectSubjectSet = (id) => {
   };
 }
 
-const fetchSubject = (id = config.zooniverseLinks.workflowId) => {
+/*  Fetches a Subject from Panoptes, based on the specified/default Panoptes
+    Workflow ID. If `initialFetch` is true, then this call to fetchSubject() is
+    meant to be the first fetchSubject of the user's session. Hence, the Subject
+    will ONLY be fetched IF no Subject has previously been fetched.
+ */
+const fetchSubject = (id = config.zooniverseLinks.workflowId, initialFetch = false) => {
   return (dispatch, getState) => {
+    if (initialFetch && getState().subject.status !== SUBJECT_STATUS.IDLE) return;
 
     dispatch({
       type: FETCH_SUBJECT,

--- a/src/ducks/subject.js
+++ b/src/ducks/subject.js
@@ -9,7 +9,10 @@ project.
  */
 import apiClient from 'panoptes-client/lib/api-client.js';
 import { config, subjectSets } from '../config';
+
 import { createClassification } from './classifications';
+import { resetAnnotations } from './annotations';
+import { resetPreviousAnnotations } from './previousAnnotations';
 import { changeFrame } from './subject-viewer'
 
 const FETCH_SUBJECT = 'FETCH_SUBJECT';
@@ -200,9 +203,7 @@ const fetchSubject = (id = config.zooniverseLinks.workflowId) => {
             favorite: currentSubject.favorite || false,
           });
 
-          //Once we have a Subject, create an empty Classification to go with it.
-          dispatch(createClassification());
-          dispatch(changeFrame(0));  //...and reset the Subject Viewer back to page 1.
+          prepareForNewSubject(dispatch);
         })
         .catch((err) => {
           console.error(err);
@@ -222,11 +223,20 @@ const fetchSubject = (id = config.zooniverseLinks.workflowId) => {
         favorite: currentSubject.favorite || false,
       });
 
-      //Once we have a Subject, create an empty Classification to go with it.
-      dispatch(createClassification());
-      dispatch(changeFrame(0));  //...and reset the Subject Viewer back to page 1.
+      prepareForNewSubject(dispatch);
     }
   };
+};
+
+/*  In preparation for a new Subject being successfully loaded, reset all
+    existing Annotations, reset all Previous Annotations, create a new
+    Classification, and set the viewer back to page 1.
+ */
+const prepareForNewSubject = (dispatch) => {
+  dispatch(resetAnnotations());
+  dispatch(resetPreviousAnnotations());
+  dispatch(createClassification());
+  dispatch(changeFrame(0));
 };
 
 export default subjectReducer;

--- a/src/ducks/subject.js
+++ b/src/ducks/subject.js
@@ -12,7 +12,7 @@ import { config, subjectSets } from '../config';
 
 import { createClassification } from './classifications';
 import { resetAnnotations } from './annotations';
-import { resetPreviousAnnotations } from './previousAnnotations';
+import { fetchPreviousAnnotations } from './previousAnnotations';
 import { changeFrame } from './subject-viewer'
 
 const FETCH_SUBJECT = 'FETCH_SUBJECT';
@@ -229,12 +229,12 @@ const fetchSubject = (id = config.zooniverseLinks.workflowId) => {
 };
 
 /*  In preparation for a new Subject being successfully loaded, reset all
-    existing Annotations, reset all Previous Annotations, create a new
-    Classification, and set the viewer back to page 1.
+    existing Annotations, (reset then) fetch the corresponding Previous
+    Annotations, create a new Classification, and set the viewer back to page 1.
  */
 const prepareForNewSubject = (dispatch) => {
   dispatch(resetAnnotations());
-  dispatch(resetPreviousAnnotations());
+  dispatch(fetchPreviousAnnotations());
   dispatch(createClassification());
   dispatch(changeFrame(0));
 };


### PR DESCRIPTION
## PR Overview
The original issue that this PR attempts to fix is phrased this way: _When a user makes Annotations on Subject A, then navigates away from the Classifier page, then returns, they will see Subject B loading, but with Subject A's Annotations._

This was due to the fact that the Subject fetching lifecycle was somewhat broken. This PR improves the lifecycle by _ensuring_ that when a new Subject is successfully fetch, all items that _should follow that event in the lifecycle_ will accordingly be reset into a blank slate.

i.e., when a new Subject is fetched successfully,
- reset Annotations
- reset Previous Annotations
- create a new, empty Classification
- reset the Subject Viewer so it's pointing back to page 1 of the Subject letter.

### Things To Keep An Eye Out For
- Are Previous Annotations still displaying properly for a B-split user?
- If a user moves away from the Classifier page, they will lose all the work they've done. This can be SUPER ANNOYING.

### Status
WIP - due to the change in the Subject fetch lifecycle, I'm still trying to confirm that the B-split works.

I'm thinking that, ultimately, `fetchAnnotations()` in `SubjectViewer.componentWillReceiveProps` needs to be folded into the lifecycle instead of being something monitored by a component.

Also, maybe have a "ClassifierPage.onUserLeavesPage = confirmUserWantsToDoThis"