### PR TITLE
Open Gold Standard Mode

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { ZooFooter } from 'zooniverse-react-components';
 import { fetchProject } from '../ducks/project';
-import { fetchWorkflow } from '../ducks/workflow';
 import Header from './Header';
 import ProjectHeader from './ProjectHeader';
 import Dialog from './Dialog';

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -89,7 +89,7 @@ class Home extends React.Component {
   }
 
   render() {
-    const isExpert = this.props.userRoles.indexOf(EXPERT || OWNER) >= 0;
+    const isExpert = this.props.userRoles.some(role => { return role === EXPERT || role === OWNER });
 
     return (
       <main className="app-content home-page">
@@ -119,7 +119,7 @@ class Home extends React.Component {
           </div>
           */}
           {isExpert && (
-            <div>
+            <div className="gold-standard-toggle">
               <input type="checkbox" onClick={this.toggleGoldStandard} id="goldStandard" checked={this.props.goldStandardMode} />
               <label htmlFor="goldStandard">Gold Standard Mode</label>
             </div>

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -8,11 +8,14 @@ import { ZooniverseLogotype, ZooniverseLogo } from 'zooniverse-react-components'
 import { config, subjectSets } from '../config';
 import SocialSection from '../components/SocialSection';
 import { selectSubjectSet } from '../ducks/subject';
+import { setGoldStandard } from '../ducks/workflow';
 import Divider from '../images/img_divider.png';
 import BostonLogo from '../images/BPL_logo.jpg';
 import IMLSLogo from '../images/imls_logo.png';
 
 const BUFFER = 50;
+const EXPERT = 'expert';
+const OWNER = 'owner';
 
 class Home extends React.Component {
   constructor() {
@@ -24,6 +27,7 @@ class Home extends React.Component {
     this.resizeBackground = this.resizeBackground.bind(this);
     this.fetchRecentSubjects = this.fetchRecentSubjects.bind(this);
     this.renderTopics = this.renderTopics.bind(this);
+    this.toggleGoldStandard = this.toggleGoldStandard.bind(this);
   }
 
   componentDidMount() {
@@ -66,6 +70,10 @@ class Home extends React.Component {
       })
   }
 
+  toggleGoldStandard() {
+    this.props.dispatch(setGoldStandard());
+  }
+
   renderTopics() {
     return subjectSets.map((set, i) => {
       return (
@@ -81,6 +89,8 @@ class Home extends React.Component {
   }
 
   render() {
+    const isExpert = this.props.userRoles.indexOf(EXPERT || OWNER) >= 0;
+
     return (
       <main className="app-content home-page">
         <div className="project-background" style={{ height: this.state.backgroundHeight }} />
@@ -108,6 +118,12 @@ class Home extends React.Component {
             {this.renderTopics()}
           </div>
           */}
+          {isExpert && (
+            <div>
+              <input type="checkbox" onClick={this.toggleGoldStandard} id="goldStandard" checked={this.props.goldStandardMode} />
+              <label htmlFor="goldStandard">Gold Standard Mode</label>
+            </div>
+          )}
         </div>
         <div id="home-logos" className="home-page__logos flex-row">
           <a href="https://www.zooniverse.org">
@@ -140,20 +156,26 @@ class Home extends React.Component {
 }
 
 Home.propTypes = {
+  goldStandardMode: PropTypes.bool,
   project: PropTypes.shape({
     description: PropTypes.string
-  })
+  }),
+  userRoles: PropTypes.arrayOf(PropTypes.string)
 };
 
 Home.defaultProps = {
+  goldStandardMode: false,
   project: {
     description: ''
-  }
+  },
+  userRoles: []
 };
 
 const mapStateToProps = (state) => {
   return {
+    goldStandardMode: state.workflow.goldStandardMode,
     project: state.project.data,
+    userRoles: state.project.userRoles
   };
 };
 

--- a/src/config.js
+++ b/src/config.js
@@ -31,6 +31,7 @@ const baseConfig = {
       workflowId: '3017',
       collabWorkflowId: '3085',
       betaSubjectSet: '4375',  //BETA_ONLY
+      gsWorkflow: '3087'
     },
   },
   production: {
@@ -43,6 +44,7 @@ const baseConfig = {
       workflowId: '5329',
       collabWorkflowId: '5339',
       betaSubjectSet: '16228',  //BETA_ONLY
+      gsWorkflow: '5356'
     },
   }
 };

--- a/src/containers/ClassifierContainer.jsx
+++ b/src/containers/ClassifierContainer.jsx
@@ -132,6 +132,12 @@ class ClassifierContainer extends React.Component {
         <SubjectViewer currentSubject={this.props.currentSubject} />
         <section className="classifier-controls">
           <div>
+            {this.props.goldStandardMode && (
+              <div className="gold-standard">
+                <i className="fa fa-star" />
+                <span>Gold Standard Mode</span>
+              </div>
+            )}
             <h2>Navigator</h2>
             <Navigator />
           </div>
@@ -303,6 +309,7 @@ ClassifierContainer.propTypes = {
     id: PropTypes.string,
   }),
   dispatch: PropTypes.func,
+  goldStandardMode: PropTypes.bool,
   guide: PropTypes.object,
   guideStatus: PropTypes.string,
   rotation: PropTypes.number,
@@ -329,6 +336,7 @@ ClassifierContainer.propTypes = {
 ClassifierContainer.defaultProps = {
   adminOverride: false,
   previousAnnotations: [],
+  goldStandardMode: false,
   guide: null,
   guideStatus: GUIDE_STATUS.IDLE,
   icons: null,
@@ -352,6 +360,7 @@ const mapStateToProps = (state, ownProps) => {
     adminOverride: state.splits.adminOverride,
     classification: state.classifications.classification,
     currentSubject: state.subject.currentSubject,
+    goldStandardMode: state.workflow.goldStandardMode,
     previousAnnotations: state.previousAnnotations.marks,
     favoriteSubject: state.subject.favorite,
     guide: state.fieldGuide.guide,

--- a/src/ducks/classifications.js
+++ b/src/ducks/classifications.js
@@ -52,7 +52,7 @@ const classificationReducer = (state = initialState, action) => {
       return Object.assign({}, state,{
         status: CLASSIFICATION_STATUS.ERROR,
       });
-    
+
     case SET_SUBJECT_COMPLETION_ANSWERS:
       const sca = Object.assign({}, state.subjectCompletionAnswers);
       sca[action.taskId] = action.answerValue;
@@ -91,6 +91,11 @@ const createClassification = () => {
     classification._workflow = getState().workflow.data;
     classification._subjects = [getState().subject.currentSubject];
 
+    const isGS = getState().workflow.goldStandardMode;
+    if (isGS) {
+      classification.gold_standard = true;
+    }
+
     dispatch({
       type: CREATE_CLASSIFICATION,
       classification
@@ -105,11 +110,11 @@ const submitClassification = () => {
     const subject = getState().subject;
     const subject_dimensions = (subject && subject.imageMetadata) ? subject.imageMetadata : [];
     const classification = getState().classifications.classification;
-    
+
     //TODO: Better error handling
     if (!classification) { alert('ERROR: Could not submit Classification.'); return; }
     //----------------
-    
+
     //Record the first task
     //This is implicitly the 'transcription' task.
     //----------------
@@ -125,7 +130,7 @@ const submitClassification = () => {
     };
     classification.annotations.push(annotations);
     //----------------
-    
+
     //Record the other tasks.
     //Note that each annotation in classification.annotations[] is in the form
     //of: { task: "T1", value: 123 || "abc" || ['a','b'] }
@@ -139,7 +144,7 @@ const submitClassification = () => {
       classification.annotations.push(answerForTask);
     });
     //----------------
-    
+
     //Save the classification
     //----------------
     dispatch({ type: SUBMIT_CLASSIFICATION });

--- a/src/ducks/classifications.js
+++ b/src/ducks/classifications.js
@@ -93,7 +93,7 @@ const createClassification = () => {
 
     const isGS = getState().workflow.goldStandardMode;
     if (isGS) {
-      classification.gold_standard = true;
+      classification.update({ gold_standard: true });
     }
 
     dispatch({

--- a/src/ducks/login.js
+++ b/src/ducks/login.js
@@ -1,6 +1,8 @@
+import apiClient from 'panoptes-client/lib/api-client.js';
 import oauth from 'panoptes-client/lib/oauth';
-import { fetchPreferences } from './project';
+import { fetchPreferences, setUserRoles } from './project';
 import { fetchSplit } from './splits';
+import { config } from '../config';
 
 // Action Types
 const SET_LOGIN_USER = 'project/user/SET_LOGIN_USER';
@@ -51,6 +53,18 @@ const logoutFromPanoptes = () => {
 
 const setLoginUser = (user) => {
  return (dispatch) => {
+   if (user) {
+     apiClient.type('project_roles').get({ project_id: config.zooniverseLinks.projectId, user_id: user.id })
+     .then(([userRoles]) => {
+       if (userRoles) {
+         dispatch(setUserRoles(userRoles.roles));
+       }
+     })
+     .catch((err) => {
+       console.warn(err);
+     })
+   };
+
    dispatch({
      type: SET_LOGIN_USER,
      user,

--- a/src/ducks/project.js
+++ b/src/ducks/project.js
@@ -15,6 +15,7 @@ const FETCH_PROJECT = 'FETCH_PROJECT';
 const FETCH_PROJECT_SUCCESS = 'FETCH_PROJECT_SUCCESS';
 const FETCH_PROJECT_ERROR = 'FETCH_PROJECT_ERROR';
 const FETCH_PREFERENCES = 'FETCH_PREFERENCES';
+const SET_USER_ROLES = 'SET_USER_ROLES';
 
 //Misc Constants
 const PROJECT_STATUS = {
@@ -32,7 +33,8 @@ const initialState = {
   status: PROJECT_STATUS.IDLE,
   id: null,
   data: {},
-  userPreferences: null
+  userPreferences: null,
+  userRoles: []
 };
 
 const classifierReducer = (state = initialState, action) => {
@@ -62,6 +64,11 @@ const classifierReducer = (state = initialState, action) => {
     case FETCH_PREFERENCES:
       return Object.assign({}, state, {
         userPreferences: action.preferences,
+      });
+
+    case SET_USER_ROLES:
+      return Object.assign({}, state, {
+        userRoles: action.roles
       });
 
     default:
@@ -132,6 +139,15 @@ const fetchPreferences = (user) => {
   }
 };
 
+const setUserRoles = (roles) => {
+  return (dispatch) => {
+    dispatch({
+      type: SET_USER_ROLES,
+      roles
+    })
+  };
+};
+
 //------------------------------------------------------------------------------
 
 //Exports
@@ -141,5 +157,6 @@ export default classifierReducer;
 export {
   fetchProject,
   fetchPreferences,
+  setUserRoles,
   PROJECT_STATUS,
 };

--- a/src/ducks/splits.js
+++ b/src/ducks/splits.js
@@ -8,6 +8,7 @@ const FETCH_SPLIT_SUCCESS = 'FETCH_SPLIT_SUCCESS';
 const FETCH_SPLIT_ERROR = 'FETCH_SPLIT_ERROR';
 const CLEAR_SPLITS = 'CLEAR_SPLITS';
 const TOGGLE_OVERRIDE = 'TOGGLE_OVERRIDE';
+const SET_VARIANT = 'SET_VARIANT';
 
 
 const SPLIT_STATUS = {
@@ -57,6 +58,11 @@ const splitReducer = (state = initialState, action) => {
     case CLEAR_SPLITS:
       return Object.assign({}, state, {
         data: null
+      });
+
+    case SET_VARIANT:
+      return Object.assign({}, state, {
+        variant: action.variant
       });
 
     default:
@@ -123,6 +129,15 @@ const toggleOverride = () => {
   };
 }
 
+const setVariant = (variant) => {
+  return (dispatch) => {
+    dispatch({
+      type: SET_VARIANT,
+      variant
+    });
+  };
+}
+
 // Exports
 export default splitReducer;
 
@@ -130,6 +145,7 @@ export {
   clearSplits,
   fetchSplit,
   toggleOverride,
+  setVariant,
   SPLIT_STATUS,
   VARIANT_TYPES
 };

--- a/src/ducks/subject.js
+++ b/src/ducks/subject.js
@@ -165,13 +165,14 @@ const fetchSubject = (id = config.zooniverseLinks.workflowId, initialFetch = fal
     dispatch({
       type: FETCH_SUBJECT,
     });
-    
+
     //BETA_ONLY
     //----------------
-    const subjectQuery = {
+    let subjectQuery = {
       workflow_id: id,
       subject_set_id: config.zooniverseLinks.betaSubjectSet,
     };
+
     //----------------
 
     //Removed for //BETA_ONLY
@@ -196,6 +197,11 @@ const fetchSubject = (id = config.zooniverseLinks.workflowId, initialFetch = fal
     }
     */
     //----------------
+
+    const gsMode = getState().workflow.goldStandardMode;
+    if (gsMode) {
+      subjectQuery = { workflow_id: config.zooniverseLinks.gsWorkflow };
+    }
 
     const fetchQueue = () => {
       apiClient.type('subjects/queued').get(subjectQuery)

--- a/src/ducks/subject.js
+++ b/src/ducks/subject.js
@@ -21,6 +21,7 @@ const FETCH_SUBJECT_ERROR = 'FETCH_SUBJECT_ERROR';
 const TOGGLE_FAVORITE = 'TOGGLE_FAVORITE';
 const SET_IMAGE_METADATA = 'SET_IMAGE_METADATA';
 const SET_SUBJECT_SET = 'SET_SUBJECT_SET';
+const CLEAR_QUEUE = 'CLEAR_QUEUE';
 
 const SUBJECT_STATUS = {
   IDLE: 'subject_status_idle',
@@ -55,6 +56,13 @@ const subjectReducer = (state = initialState, action) => {
         id: action.id,
         queue: action.queue,
         favorite: action.favorite,
+      });
+
+    case CLEAR_QUEUE:
+      return Object.assign({}, state, {
+        queue: [],
+        status: action.status,
+        currentSubject: action.currentSubject
       });
 
     case SET_SUBJECT_SET:
@@ -251,9 +259,20 @@ const prepareForNewSubject = (dispatch, subject) => {
   dispatch(changeFrame(0));
 };
 
+const clearQueue = () => {
+  return (dispatch) => {
+    dispatch({
+      type: CLEAR_QUEUE,
+      status: SUBJECT_STATUS.IDLE,
+      currentSubject: null
+    });
+  }
+}
+
 export default subjectReducer;
 
 export {
+  clearQueue,
   toggleFavorite,
   fetchSubject,
   selectSubjectSet,

--- a/src/ducks/workflow.js
+++ b/src/ducks/workflow.js
@@ -1,10 +1,11 @@
 import apiClient from 'panoptes-client/lib/api-client.js';
 import { config } from '../config';
-import { VARIANT_TYPES } from './splits';
+import { fetchSplit, setVariant, VARIANT_TYPES } from './splits';
 
 const FETCH_WORKFLOW = 'FETCH_WORKFLOW';
 const FETCH_WORKFLOW_SUCCESS = 'FETCH_WORKFLOW_SUCCESS';
 const FETCH_WORKFLOW_ERROR = 'FETCH_WORKFLOW_ERROR';
+const SET_GOLD_STANDARD = 'SET_GOLD_STANDARD';
 
 const WORKFLOW_STATUS = {
   IDLE: 'workflow_status_idle',
@@ -17,6 +18,7 @@ const initialState = {
   status: WORKFLOW_STATUS.IDLE,
   id: null,
   data: null,
+  goldStandardMode: false
 };
 
 const workflowReducer = (state = initialState, action) => {
@@ -40,6 +42,11 @@ const workflowReducer = (state = initialState, action) => {
         status: WORKFLOW_STATUS.ERROR,
       });
 
+    case SET_GOLD_STANDARD:
+      return Object.assign({}, state, {
+        goldStandardMode: action.gs
+      });
+
     default:
       return state;
   };
@@ -50,6 +57,12 @@ const fetchWorkflow = (variant = VARIANT_TYPES.INDIVIDUAL) => {
     config.zooniverseLinks.collabWorkflowId :
     config.zooniverseLinks.workflowId;
 
+  return (dispatch) => {
+    dispatch(retrieveWorkflow(id));
+  };
+}
+
+const retrieveWorkflow = (id) => {
   return (dispatch) => {
     dispatch({
       type: FETCH_WORKFLOW,
@@ -73,9 +86,25 @@ const fetchWorkflow = (variant = VARIANT_TYPES.INDIVIDUAL) => {
   };
 }
 
+const setGoldStandard = () => {
+  return (dispatch, getState) => {
+    const isActive = !getState().workflow.goldStandardMode;
+    const user = getState().login.user;
+
+    if (isActive) {
+      dispatch(setVariant(VARIANT_TYPES.INDIVIDUAL));
+      dispatch(retrieveWorkflow(config.zooniverseLinks.gsWorkflow));
+    } else {
+      dispatch(fetchSplit(user));
+    }
+    dispatch({ type: SET_GOLD_STANDARD, gs: isActive });
+  };
+};
+
 export default workflowReducer;
 
 export {
   fetchWorkflow,
+  setGoldStandard,
   WORKFLOW_STATUS,
 };

--- a/src/ducks/workflow.js
+++ b/src/ducks/workflow.js
@@ -1,6 +1,7 @@
 import apiClient from 'panoptes-client/lib/api-client.js';
 import { config } from '../config';
 import { fetchSplit, setVariant, VARIANT_TYPES } from './splits';
+import { clearQueue } from './subject';
 
 const FETCH_WORKFLOW = 'FETCH_WORKFLOW';
 const FETCH_WORKFLOW_SUCCESS = 'FETCH_WORKFLOW_SUCCESS';
@@ -94,6 +95,7 @@ const setGoldStandard = () => {
     if (isActive) {
       dispatch(setVariant(VARIANT_TYPES.INDIVIDUAL));
       dispatch(retrieveWorkflow(config.zooniverseLinks.gsWorkflow));
+      dispatch(clearQueue());
     } else {
       dispatch(fetchSplit(user));
     }

--- a/src/styles/components/classifier-page.styl
+++ b/src/styles/components/classifier-page.styl
@@ -101,3 +101,6 @@
 
   span
     margin-left: 0.5em
+
+.gold-standard
+  color: goldenrod

--- a/src/styles/components/home-page.styl
+++ b/src/styles/components/home-page.styl
@@ -272,3 +272,10 @@
 
   .project-background
     background-image: url('../images/home-bg.jpg')
+
+.gold-standard-toggle
+  @extend .secondary-head
+  font-size: 0.85em
+
+  input
+    margin: 0.5em  


### PR DESCRIPTION
This PR opens a Gold Standard Mode which will have access to a separate workflow to record gold standard annotations. I initially set out to refactor the code a bit, but I feel like this is a case where a good bit of code is needed to accomplish a simple task (fetching roles, running conditionals, rendering based on these results).

Currently, only an owner and expert can enter gold standard mode via the home screen. I came across two minor issues with this branch, but I'm not sure it's worth a fix since (as to my knowledge) we only have one person currently who will be annotating under this mode.

1) If a user logs out while in gold standard mode, the mode will not be reset.
2) There is a reloading and jumping of the home page when gold standard mode is toggled (probably because a new workflow is fetched).

If we were to have many experts classifying, this might be worth more attention, but I'm not sure it's necessary given such a low number of experts. However, I'm happy to push a fix if you find this blocking.