### PR TITLE
Fix .remember GA Call

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -54,7 +54,7 @@ class App extends React.Component {
       this.googleLogger.remember({ userID: nextProps.user.id });
     }
 
-    if (nextProps.splitStatus === SPLIT_STATUS.READY && this.props.variant !== nextProps.variant) {
+    if (nextProps.splitStatus !== this.props.splitStatus && nextProps.splitStatus === SPLIT_STATUS.READY) {
       this.googleLogger.remember({ cohort: nextProps.variant, experiment: nextProps.splitID });
     }
 


### PR DESCRIPTION
Good this was caught in time for beta. There was an important line that was slightly off where the GA client wouldn't remember a variant if it never changed from individual. 