### PR TITLE
Fix Modal Placement on IE

### DIFF
--- a/src/components/Dialog.jsx
+++ b/src/components/Dialog.jsx
@@ -22,7 +22,7 @@ class Dialog extends React.Component {
     const width = 800;
     const height = 425;
     const x = window.innerWidth / 2 - (width / 2);
-    const y = window.innerHeight / 2 - (height / 2) + window.scrollY;
+    const y = window.innerHeight / 2 - (height / 2) + window.pageYOffset;
 
     const defaultPosition = { x, y, height, width };
     const enableResize = this.props.enableResize ? { bottomRight: true } : false;


### PR DESCRIPTION
This was a relatively easy fix. The dialog modal wasn't placing right on IE because the browser can't recognize `window.scrollY`. Alternatively, I used `window.pageYOffset`.

I believe this is the final fix needed to close #18 
Closes #18 