### PR TITLE
Disable background annotate

### DIFF
--- a/src/containers/ClassifierContainer.jsx
+++ b/src/containers/ClassifierContainer.jsx
@@ -146,7 +146,7 @@ class ClassifierContainer extends React.Component {
               onClick={this.useAnnotationTool}
             >
               <span className="classifier-toolbar__icon">
-                <i className={`fa fa-plus-circle ${disableAnnotate ? 'disable-icon' : ''}`} />
+                <i className={`fa fa-plus-circle ${disableAnnotate && 'disable-icon'}`} />
               </span>
               <span>Annotate</span>
             </button>

--- a/src/containers/ClassifierContainer.jsx
+++ b/src/containers/ClassifierContainer.jsx
@@ -89,6 +89,7 @@ class ClassifierContainer extends React.Component {
   }
 
   render() {
+    const disableAnnotate = this.props.selectedAnnotation !== null;
     const isAdmin = this.props.user && this.props.user.admin;
     const shownMarksClass = (MARKS_STATE.ALL === this.props.shownMarks) ? "fa fa-eye" :
       (MARKS_STATE.USER === this.props.shownMarks) ? "fa fa-eye-slash" : "fa fa-eye-slash grey";
@@ -140,11 +141,12 @@ class ClassifierContainer extends React.Component {
             <h2>Toolbar</h2>
 
             <button
+              disabled={disableAnnotate}
               className={(this.props.viewerState === SUBJECTVIEWER_STATE.ANNOTATING) ? 'flat-button block selected' : 'flat-button block'}
               onClick={this.useAnnotationTool}
             >
               <span className="classifier-toolbar__icon">
-                <i className="fa fa-plus-circle" />
+                <i className={`fa fa-plus-circle ${disableAnnotate ? 'disable-icon' : ''}`} />
               </span>
               <span>Annotate</span>
             </button>
@@ -312,6 +314,9 @@ ClassifierContainer.propTypes = {
   }),
   rotation: PropTypes.number,
   scaling: PropTypes.number,
+  selectedAnnotation: PropTypes.shape({
+    status: PropTypes.string
+  }),
   shownMarks: PropTypes.number,
   tutorial: PropTypes.shape({
     steps: PropTypes.array
@@ -335,6 +340,7 @@ ClassifierContainer.defaultProps = {
   project: null,
   rotation: 0,
   scaling: 1,
+  selectedAnnotation: null,
   shownMarks: 0,
   tutorial: null,
   tutorialStatus: TUTORIAL_STATUS.IDLE,
@@ -361,6 +367,7 @@ const mapStateToProps = (state, ownProps) => {
     project: state.project.data,
     rotation: state.subjectViewer.rotation,
     scaling: state.subjectViewer.scaling,
+    selectedAnnotation: state.annotations.selectedAnnotation,
     shownMarks: state.subjectViewer.shownMarks,
     splits: state.splits.splits,
     tutorial: state.tutorial.data,

--- a/src/styles/components/classifier-page.styl
+++ b/src/styles/components/classifier-page.styl
@@ -76,6 +76,9 @@
           display: inline
           font-size: 1rem
 
+        .disable-icon
+          color: $light-grey
+
         span
           align-self: center
           margin-right: 0.75rem


### PR DESCRIPTION
This had somewhat been cleared up by switching the subject viewer status away from annotate when a selected annotation existed, but this change disables the button from being pressed, thus closing an issue.

Closes #59 