### PR TITLE
Reveal Feedback Forms

### DIFF
--- a/src/components/ProjectHeader.jsx
+++ b/src/components/ProjectHeader.jsx
@@ -71,6 +71,9 @@ class ProjectHeader extends React.Component {
               Talk
             </button>
           </a>
+          <a className="project-header__link" href="#">
+            Feedback
+          </a>
         </nav>
       </div>
     )

--- a/src/components/ProjectHeader.jsx
+++ b/src/components/ProjectHeader.jsx
@@ -27,8 +27,9 @@ class ProjectHeader extends React.Component {
   }
 
   feedbackVariant() {
-    return this.props.variant === VARIANT_TYPES.INDIVIDUAL ?
-      'http://bit.ly/2mqvwvJ' : 'http://bit.ly/2zYLumx';
+    return this.props.variant === VARIANT_TYPES.INDIVIDUAL
+      ? 'https://goo.gl/forms/x0zAhMiS2KlzAMlE3'  //Individual-type users.
+      : 'https://goo.gl/forms/SfBPc0QyjGNkeWcK2';  //Collaborative-type users.
   }
 
   render() {

--- a/src/components/ProjectHeader.jsx
+++ b/src/components/ProjectHeader.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router';
+import { connect } from 'react-redux';
 import { config } from '../config';
+import { VARIANT_TYPES } from '../ducks/splits';
 
 class ProjectHeader extends React.Component {
   constructor(props) {
@@ -9,6 +11,7 @@ class ProjectHeader extends React.Component {
 
     this.aboutClick = this.aboutClick.bind(this);
     this.talkClick = this.talkClick.bind(this);
+    this.feedbackVariant = this.feedbackVariant.bind(this);
   }
 
   aboutClick() {
@@ -21,6 +24,11 @@ class ProjectHeader extends React.Component {
     if (this.context.googleLogger) {
       this.context.googleLogger.logEvent({ type: 'header-talk-click' });
     }
+  }
+
+  feedbackVariant() {
+    return this.props.variant === VARIANT_TYPES.INDIVIDUAL ?
+      'http://bit.ly/2mqvwvJ' : 'http://bit.ly/2zYLumx';
   }
 
   render() {
@@ -71,7 +79,11 @@ class ProjectHeader extends React.Component {
               Talk
             </button>
           </a>
-          <a className="project-header__link" href="#">
+          <a
+            className="project-header__link"
+            href={this.feedbackVariant()}
+            target="_blank"
+          >
             Feedback
           </a>
         </nav>
@@ -82,14 +94,22 @@ class ProjectHeader extends React.Component {
 
 ProjectHeader.defaultProps = {
   showTitle: false,
+  variant: VARIANT_TYPES.INDIVIDUAL
 };
 
 ProjectHeader.propTypes = {
   showTitle: PropTypes.bool,
+  variant: PropTypes.string
 };
 
 ProjectHeader.contextTypes = {
-  googleLogger: PropTypes.object
+  googleLogger: PropTypes.object,
 };
 
-export default ProjectHeader;
+const mapStateToProps = (state) => {
+  return {
+    variant: state.splits.variant,
+  };
+};
+
+export default connect(mapStateToProps)(ProjectHeader);

--- a/src/styles/components/project-header.styl
+++ b/src/styles/components/project-header.styl
@@ -23,6 +23,7 @@
   &__link
     flex: 0 0 auto
     color: $dark-grey
+    cursor: pointer
     display: inline-block
     letter-spacing: (0.9/15)em
     margin: 0.5rem 0rem 0rem 1.25rem


### PR DESCRIPTION
This PR adds a link for feedback forms on the project header in preparation for beta launch. A user will be directed to an individual or collaborative form depending on which variant group is used.