### PR TITLE
Typo fix - @BPLBostom

### DIFF
--- a/src/components/SocialSection.jsx
+++ b/src/components/SocialSection.jsx
@@ -87,7 +87,7 @@ const SocialSection = ({ project, subjectsOfNote }) =>
               <i className="fa fa-twitter fa-2x"/>
               <div>
                 <span>Twitter</span>
-                <span>@BPLBostom</span>
+                <span>@BPLBoston</span>
               </div>
             </a>
           </div>


### PR DESCRIPTION
## PR Overview
This PR fixes the `@BPLBostom` typo on the home page's Social Section ("In The News")

### Status
Minor fix, merging.