### PR TITLE
Save Classifications for Later - Mk2

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "graphql-request": "^1.3.4",
     "history": "^4.6.1",
     "markdownz": "~7.3.1",
-    "panoptes-client": "^2.7.2",
+    "panoptes-client": "^2.8.0",
     "prop-types": "^15.5.10",
     "react": "^15.4.1",
     "react-dom": "^15.4.1",

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -73,7 +73,7 @@ class App extends React.Component {
     const showTitle = path === '/classify';
 
     return (
-      <div>
+      <div style={{ "position": "relative" }}>
         <Header />
         <ProjectHeader showTitle={showTitle} />
         {this.props.children}

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -73,7 +73,7 @@ class App extends React.Component {
     const showTitle = path === '/classify';
 
     return (
-      <div style={{ "position": "relative" }}>
+      <div>
         <Header />
         <ProjectHeader showTitle={showTitle} />
         {this.props.children}

--- a/src/components/ClassificationPrompt.jsx
+++ b/src/components/ClassificationPrompt.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import apiClient from 'panoptes-client/lib/api-client';
 import { connect } from 'react-redux';
 import { retrieveClassification } from '../ducks/classifications';
+import { fetchSubject } from '../ducks/subject';
 
 class ClassificationPrompt extends React.Component {
   constructor(props) {
@@ -12,30 +14,60 @@ class ClassificationPrompt extends React.Component {
   }
 
   loadClassification(e) {
-    const id = localStorage.getItem('classificationID');
+    const id = localStorage.getItem(`${this.props.user.id}.classificationID`);
 
     this.props.dispatch(retrieveClassification(id));
     this.props.onClose && this.props.onClose(e);
   }
 
   cancelClassification(e) {
+    const id = localStorage.getItem(`${this.props.user.id}.classificationID`);
+    localStorage.removeItem(`${this.props.user.id}.classificationID`);
 
+    apiClient.type('classifications/incomplete').get({ id })
+    .then(([classification]) => {
+      classification.delete();
+    })
+    .catch((err) => {
+      console.warn(err);
+    })
+    this.props.dispatch(fetchSubject());
     this.props.onClose && this.props.onClose(e);
   }
 
   render() {
     return (
-      <div>
-        <h3>Do you want to continue a recent classification</h3>
-        <button onClick={this.loadClassification}>Yes</button>
-        <button onClick={this.cancelClassification}>No</button>
+      <div className="classification-prompt">
+        <h2>We found your saved work!</h2>
+        <span>
+          Would you like to continue where you left off or begin working on a
+          new manuscript? <i>Note:</i> If you select "No", you will lose this
+          saved work from a previous manuscript.
+        </span>
+        <div>
+          <button className="button" onClick={this.loadClassification}>Yes</button>
+          <button className="button" onClick={this.cancelClassification}>No</button>
+        </div>
       </div>
     );
   }
 };
 
-ClassificationPrompt.propTypes = {
-  onClose: PropTypes.func
+ClassificationPrompt.defaultProps = {
+  user: null
 }
 
-export default connect()(ClassificationPrompt);
+ClassificationPrompt.propTypes = {
+  onClose: PropTypes.func,
+  user: PropTypes.shape({
+    id: PropTypes.string,
+  })
+}
+
+const mapStateToProps = (state) => {
+  return {
+    user: state.login.user,
+  };
+};
+
+export default connect(mapStateToProps)(ClassificationPrompt);

--- a/src/components/ClassificationPrompt.jsx
+++ b/src/components/ClassificationPrompt.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { retrieveClassification } from '../ducks/classifications';
+
+class ClassificationPrompt extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.loadClassification = this.loadClassification.bind(this);
+    this.cancelClassification = this.cancelClassification.bind(this);
+  }
+
+  loadClassification(e) {
+    const id = localStorage.getItem('classificationID');
+
+    this.props.dispatch(retrieveClassification(id));
+    this.props.onClose && this.props.onClose(e);
+  }
+
+  cancelClassification(e) {
+
+    this.props.onClose && this.props.onClose(e);
+  }
+
+  render() {
+    return (
+      <div>
+        <h3>Do you want to continue a recent classification</h3>
+        <button onClick={this.loadClassification}>Yes</button>
+        <button onClick={this.cancelClassification}>No</button>
+      </div>
+    );
+  }
+};
+
+ClassificationPrompt.propTypes = {
+  onClose: PropTypes.func
+}
+
+export default connect()(ClassificationPrompt);

--- a/src/components/ClassificationPrompt.jsx
+++ b/src/components/ClassificationPrompt.jsx
@@ -15,6 +15,7 @@ class ClassificationPrompt extends React.Component {
 
   loadClassification(e) {
     const id = localStorage.getItem(`${this.props.user.id}.classificationID`);
+    console.log(id);
 
     this.props.dispatch(retrieveClassification(id));
     this.props.onClose && this.props.onClose(e);
@@ -25,12 +26,12 @@ class ClassificationPrompt extends React.Component {
     localStorage.removeItem(`${this.props.user.id}.classificationID`);
 
     apiClient.type('classifications/incomplete').get({ id })
-    .then(([classification]) => {
-      classification.delete();
-    })
-    .catch((err) => {
-      console.warn(err);
-    })
+      .then(([classification]) => {
+        classification.delete();
+      })
+      .catch((err) => {
+        console.warn(err);
+      });
     this.props.dispatch(fetchSubject());
     this.props.onClose && this.props.onClose(e);
   }
@@ -44,7 +45,7 @@ class ClassificationPrompt extends React.Component {
           new manuscript?
         </span>
         <span>
-          <i>Note:</i> If you select "No", you will lose any
+          <i>Note:</i> If you select &quot;New Manuscript&quot;&#44;, you will lose any
           saved work from a previous manuscript.
         </span>
         <div>
@@ -54,18 +55,19 @@ class ClassificationPrompt extends React.Component {
       </div>
     );
   }
-};
-
-ClassificationPrompt.defaultProps = {
-  user: null
 }
 
+ClassificationPrompt.defaultProps = {
+  user: null,
+};
+
 ClassificationPrompt.propTypes = {
+  dispatch: PropTypes.func,
   onClose: PropTypes.func,
   user: PropTypes.shape({
     id: PropTypes.string,
-  })
-}
+  }),
+};
 
 const mapStateToProps = (state) => {
   return {

--- a/src/components/ClassificationPrompt.jsx
+++ b/src/components/ClassificationPrompt.jsx
@@ -40,13 +40,16 @@ class ClassificationPrompt extends React.Component {
       <div className="classification-prompt">
         <h2>We found your saved work!</h2>
         <span>
-          Would you like to continue where you left off or begin working on a
-          new manuscript? <i>Note:</i> If you select "No", you will lose this
+          Would you like to continue your saved transcription or begin working on a
+          new manuscript?
+        </span>
+        <span>
+          <i>Note:</i> If you select "No", you will lose any
           saved work from a previous manuscript.
         </span>
         <div>
-          <button className="button" onClick={this.loadClassification}>Yes</button>
-          <button className="button" onClick={this.cancelClassification}>No</button>
+          <button className="button" onClick={this.cancelClassification}>New Manuscript</button>
+          <button className="button" onClick={this.loadClassification}>Continue Saved</button>
         </div>
       </div>
     );

--- a/src/components/ClassificationPrompt.jsx
+++ b/src/components/ClassificationPrompt.jsx
@@ -15,7 +15,6 @@ class ClassificationPrompt extends React.Component {
 
   loadClassification(e) {
     const id = localStorage.getItem(`${this.props.user.id}.classificationID`);
-    console.log(id);
 
     this.props.dispatch(retrieveClassification(id));
     this.props.onClose && this.props.onClose(e);

--- a/src/components/ClassificationPrompt.jsx
+++ b/src/components/ClassificationPrompt.jsx
@@ -44,7 +44,7 @@ class ClassificationPrompt extends React.Component {
           new manuscript?
         </span>
         <span>
-          <i>Note:</i> If you select &quot;New Manuscript&quot;&#44;, you will lose any
+          <i>Note:</i> If you select &quot;New Manuscript&quot;, you will lose any
           saved work from a previous manuscript.
         </span>
         <div>

--- a/src/components/Dialog.jsx
+++ b/src/components/Dialog.jsx
@@ -27,6 +27,9 @@ class Dialog extends React.Component {
     const defaultPosition = { x, y, height, width };
     const enableResize = this.props.enableResize ? { bottomRight: true } : false;
     const resizeClass = this.props.enableResize ? { bottomRight: "drag-handler" } : false;
+    const children = React.Children.map(this.props.children, (child) => {
+      return React.cloneElement(child, { onClose: this.close });
+    });
 
     return (
       <Rnd
@@ -39,7 +42,7 @@ class Dialog extends React.Component {
         <div className="popup dialog" ref={(c)=>{this.popupBody=c}} onClick={(e) => { return e.target === this.popupBody && this.close(e); }}>
           <div className="popup-content dialog-content">
             <button className="close-button" onClick={this.close}>X</button>
-            {this.props.children}
+            {children}
           </div>
         </div>
       </Rnd>

--- a/src/components/Dialog.jsx
+++ b/src/components/Dialog.jsx
@@ -19,7 +19,7 @@ class Dialog extends React.Component {
   }
 
   render() {
-    const width = 800;
+    const width = this.props.isPrompt ? 400 : 800;
     const height = 425;
     const x = window.innerWidth / 2 - (width / 2);
     const y = window.innerHeight / 2 - (height / 2) + window.scrollY;
@@ -41,7 +41,9 @@ class Dialog extends React.Component {
       >
         <div className="popup dialog" ref={(c)=>{this.popupBody=c}} onClick={(e) => { return e.target === this.popupBody && this.close(e); }}>
           <div className="popup-content dialog-content">
-            <button className="close-button" onClick={this.close}>X</button>
+            {!this.props.isPrompt && (
+              <button className="close-button" onClick={this.close}>X</button>
+            )}
             {children}
           </div>
         </div>
@@ -64,16 +66,19 @@ class Dialog extends React.Component {
 }
 
 Dialog.defaultProps = {
-  enableResize: true
+  enableResize: true,
+  isPrompt: false
 }
 
 Dialog.propTypes = {
   dispatch: PropTypes.func,
-  enableResize: PropTypes.bool
+  enableResize: PropTypes.bool,
+  isPrompt: PropTypes.bool
 }
 
 const mapStateToProps = (state) => ({
-  enableResize: state.dialog.enableResize
+  enableResize: state.dialog.enableResize,
+  isPrompt: state.dialog.isPrompt
 });
 
 export default connect(mapStateToProps)(Dialog);

--- a/src/components/Dialog.jsx
+++ b/src/components/Dialog.jsx
@@ -19,7 +19,7 @@ class Dialog extends React.Component {
   }
 
   render() {
-    const width = this.props.isPrompt ? 400 : 800;
+    const width = this.props.isPrompt ? 450 : 800;
     const height = 425;
     const x = window.innerWidth / 2 - (width / 2);
     const y = window.innerHeight / 2 - (height / 2) + window.scrollY;

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -30,6 +30,7 @@ class Home extends React.Component {
     this.resizeBackground();
     this.fetchRecentSubjects();
     addEventListener('resize', this.resizeBackground);
+    window.scrollTo(0, 0);
   }
 
   componentWillUnmount() {

--- a/src/components/SaveSuccess.jsx
+++ b/src/components/SaveSuccess.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const SaveSuccess = ({ onClose }) => {
+  return (
+    <div className="save-confirm">
+      <h3>Save Success!</h3>
+      <span>
+         Your work-in-progress has been saved. As long as you&apos;re logged in, you
+         can visit this page again at a later time to continue where you left off.
+      </span>
+      <button className="confirm-button" type="submit" onClick={onClose}>OK</button>
+    </div>
+
+  );
+};
+
+SaveSuccess.propTypes = {
+  onClose: PropTypes.func,
+};
+
+export default SaveSuccess;

--- a/src/containers/ClassifierContainer.jsx
+++ b/src/containers/ClassifierContainer.jsx
@@ -4,7 +4,6 @@ import { connect } from 'react-redux';
 import { Split } from 'seven-ten';
 import { Tutorial } from 'zooniverse-react-components';
 import { config } from '../config';
-import { browserHistory } from 'react-router';
 
 import {
   setRotation, setContrast, resetView,
@@ -127,7 +126,7 @@ class ClassifierContainer extends React.Component {
             <img className="divider" role="presentation" src={Divider} />
 
             {this.props.user && (
-              <button href="#" className="white-green button" onClick={this.saveCurrentClassification}>Save &amp; Close</button>
+              <button className="white-green button" onClick={this.saveCurrentClassification}>Save Progress</button>
             )}
 
             <button className="white-green button" onClick={this.prepareSubmitClassificationForm}>Finish</button>
@@ -311,7 +310,6 @@ class ClassifierContainer extends React.Component {
   }
 
   saveCurrentClassification() {
-    browserHistory.push('/');
     this.props.dispatch(saveClassification());
   }
 }

--- a/src/containers/ClassifierContainer.jsx
+++ b/src/containers/ClassifierContainer.jsx
@@ -17,7 +17,8 @@ import { toggleFavorite } from '../ducks/subject';
 import { toggleDialog } from '../ducks/dialog';
 import { VARIANT_TYPES, toggleOverride } from '../ducks/splits';
 import {
-  createClassification, submitClassification
+  createClassification, saveClassification,
+  submitClassification
 } from '../ducks/classifications';
 
 import SubjectViewer from './SubjectViewer';
@@ -53,6 +54,7 @@ class ClassifierContainer extends React.Component {
     this.prepareSubmitClassificationForm = this.prepareSubmitClassificationForm.bind(this);
     this.toggleAdminOverride = this.toggleAdminOverride.bind(this);
     this.toggleFieldGuide = this.toggleFieldGuide.bind(this);
+    this.saveCurrentClassification = this.saveCurrentClassification.bind(this);
 
     this.state = {
       popup: null,
@@ -122,6 +124,9 @@ class ClassifierContainer extends React.Component {
             <button className="white-red button">Your Crib Sheet</button>*/}
             <img className="divider" role="presentation" src={Divider} />
 
+            {this.props.user && (
+              <button href="#" className="white-green button" onClick={this.saveCurrentClassification}>Save &amp; Close</button>
+            )}
 
             <button className="white-green button" onClick={this.prepareSubmitClassificationForm}>Finish</button>
           </div>
@@ -294,6 +299,10 @@ class ClassifierContainer extends React.Component {
 
   showCollections() {
     this.setState({ popup: <CollectionsContainer closePopup={this.closePopup} /> });
+  }
+
+  saveCurrentClassification() {
+    this.props.dispatch(saveClassification());
   }
 }
 

--- a/src/containers/ClassifierContainer.jsx
+++ b/src/containers/ClassifierContainer.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { Split } from 'seven-ten';
 import { Tutorial } from 'zooniverse-react-components';
 import { config } from '../config';
+import { browserHistory } from 'react-router';
 
 import {
   setRotation, setContrast, resetView,
@@ -302,6 +303,7 @@ class ClassifierContainer extends React.Component {
   }
 
   saveCurrentClassification() {
+    browserHistory.push('/');
     this.props.dispatch(saveClassification());
   }
 }

--- a/src/containers/ClassifierContainer.jsx
+++ b/src/containers/ClassifierContainer.jsx
@@ -19,7 +19,7 @@ import { toggleFavorite } from '../ducks/subject';
 import { toggleDialog } from '../ducks/dialog';
 import { VARIANT_TYPES, toggleOverride } from '../ducks/splits';
 import {
-  createClassification, saveClassification,
+  createClassification, saveClassificationInProgress,
   submitClassification
 } from '../ducks/classifications';
 
@@ -344,7 +344,7 @@ class ClassifierContainer extends React.Component {
   }
 
   saveCurrentClassification() {
-    this.props.dispatch(saveClassification());
+    this.props.dispatch(saveClassificationInProgress());
   }
 }
 

--- a/src/ducks/annotations.js
+++ b/src/ducks/annotations.js
@@ -14,6 +14,7 @@ const DELETE_SELECTED_ANNOTATION = 'DELETE_SELECTED_ANNOTATION';
 const COLLABORATE_WITH_ANNOTATION = 'COLLABORATE_WITH_ANNOTATION';
 const UPDATE_TEXT = 'UPDATE_TEXT';
 const SAVE_TEXT = 'SAVE_TEXT';
+const SET_ANNOTATIONS = 'SET_ANNOTATIONS';
 
 //Misc Constants
 const ANNOTATION_STATUS = {
@@ -93,6 +94,11 @@ const annotationsReducer = (state = initialState, action) => {
 
       return Object.assign({}, state, {
         annotations: userAnnotations
+      });
+
+    case SET_ANNOTATIONS:
+      return Object.assign({}, state, {
+        annotations: action.annotations
       });
 
     case UPDATE_TEXT:
@@ -216,6 +222,15 @@ const collaborateWithAnnotation = (annotation, text) => {
   };
 };
 
+const setAnnotations = (annotations) => {
+  return(dispatch) => {
+    dispatch({
+      type: SET_ANNOTATIONS,
+      annotations
+    });
+  };
+};
+
 export default annotationsReducer;
 
 //------------------------------------------------------------------------------
@@ -223,7 +238,7 @@ export default annotationsReducer;
 //Exports
 
 export {
-  resetAnnotations,
+  resetAnnotations, setAnnotations,
   addAnnotationPoint, completeAnnotation,
   selectAnnotation, unselectAnnotation,
   deleteSelectedAnnotation,

--- a/src/ducks/classifications.js
+++ b/src/ducks/classifications.js
@@ -6,7 +6,7 @@ import { Split } from 'seven-ten';
 
 import { resetAnnotations, setAnnotations } from './annotations';
 import { resetPreviousAnnotations, fetchAnnotations } from './previousAnnotations';
-import { fetchSubject } from './subject';
+import { fetchSubject, fetchSavedSubject } from './subject';
 import { resetView } from './subject-viewer';
 
 import { toggleDialog } from '../ducks/dialog';
@@ -221,6 +221,7 @@ const retrieveClassification = (id) => {
       const subjectId = classification.links.subjects.shift();
       const annotations = classification.annotations.shift();
       dispatch(setAnnotations(annotations.value));
+      dispatch(fetchSavedSubject(subjectId));
 
       dispatch({
         type: CREATE_CLASSIFICATION,

--- a/src/ducks/classifications.js
+++ b/src/ducks/classifications.js
@@ -70,7 +70,7 @@ const classificationReducer = (state = initialState, action) => {
       return Object.assign({}, state, {
         subjectCompletionAnswers: sca,
       });
-    
+
     case UPDATE_CLASSIFICATION:  //Useful when the Classification object is changed, and we need to get a 'fresh one' from Panoptes.
       return Object.assign({}, state, {
         classification: action.classification,
@@ -152,7 +152,7 @@ const submitClassification = () => {
     //Note that each annotation in classification.annotations[] is in the form
     //of: { task: "T1", value: 123 || "abc" || ['a','b'] }
     //----------------
-    
+
     const sca = getState().classifications.subjectCompletionAnswers;
     Object.keys(sca).map((taskId) => {
       const answerForTask = {
@@ -167,6 +167,7 @@ const submitClassification = () => {
     //----------------
     dispatch({ type: SUBMIT_CLASSIFICATION });
     classification.update({
+      annotations: classification.annotations,
       completed: true,
       'metadata.session': getSessionID(),
       'metadata.finished_at': (new Date()).toISOString(),
@@ -252,9 +253,9 @@ const saveClassificationInProgress = () => {
       task,
       value: getState().annotations.annotations,
     };
-    
+
     const classification = getState().classifications.classification;
-    
+
     classification.update({
       annotations: [annotations],
       completed: false,

--- a/src/ducks/classifications.js
+++ b/src/ducks/classifications.js
@@ -1,11 +1,9 @@
-import React from 'react';
 import apiClient from 'panoptes-client/lib/api-client.js';
 import counterpart from 'counterpart';
 import { getSessionID } from '../lib/get-session-id';
 import { Split } from 'seven-ten';
 
-import { resetAnnotations, setAnnotations } from './annotations';
-import { resetPreviousAnnotations, fetchAnnotations } from './previousAnnotations';
+import { setAnnotations } from './annotations';
 import { fetchSubject, fetchSavedSubject } from './subject';
 import { resetView } from './subject-viewer';
 
@@ -104,7 +102,6 @@ const createClassification = () => {
       type: CREATE_CLASSIFICATION,
       classification
     });
-
   };
 };
 

--- a/src/ducks/classifications.js
+++ b/src/ducks/classifications.js
@@ -212,13 +212,10 @@ const retrieveClassification = (id) => {
   return (dispatch) => {
     apiClient.type('classifications/incomplete').get({ id })
       .then(([classification]) => {
-        console.log(classification);
         const subjectId = classification.links.subjects.shift();
         const annotations = classification.annotations.shift();
         dispatch(setAnnotations(annotations.value));
         dispatch(fetchSavedSubject(subjectId));
-        console.log(classification);
-        console.log(annotations);
         dispatch({
           type: CREATE_CLASSIFICATION,
           classification,

--- a/src/ducks/classifications.js
+++ b/src/ducks/classifications.js
@@ -146,6 +146,7 @@ const submitClassification = () => {
     //Note that each annotation in classification.annotations[] is in the form
     //of: { task: "T1", value: 123 || "abc" || ['a','b'] }
     //----------------
+    
     const sca = getState().classifications.subjectCompletionAnswers;
     Object.keys(sca).map((taskId) => {
       const answerForTask = {
@@ -158,7 +159,9 @@ const submitClassification = () => {
 
     //Save the classification
     //----------------
+    
     dispatch({ type: SUBMIT_CLASSIFICATION });
+    
     classification.update({
       completed: true,
       'metadata.session': getSessionID(),
@@ -245,23 +248,25 @@ const saveClassification = () => {
       task,
       value: getState().annotations.annotations,
     };
-
+    
     const classification = getState().classifications.classification;
+    
     classification.update({
       annotations: [annotations],
       completed: false,
       'metadata.session': getSessionID(),
       'metadata.finished_at': (new Date()).toISOString(),
-    }).save()
-      .catch((err) => {
-        console.log(err);
-      })
-      .then((savedClassification) => {
-        if (user) {
-          localStorage.setItem(`${user.id}.classificationID`, savedClassification.id);
-        }
-        dispatch(toggleDialog(<SaveSuccess />, false, true));
-      });
+    })
+    .save()
+    .then((savedClassification) => {
+      if (user) {
+        localStorage.setItem(`${user.id}.classificationID`, savedClassification.id);
+      }
+      dispatch(toggleDialog(<SaveSuccess />, false, true));
+    })
+    .catch((err) => {
+      console.log(err);
+    });
   };
 };
 

--- a/src/ducks/classifications.js
+++ b/src/ducks/classifications.js
@@ -126,7 +126,7 @@ const submitClassification = () => {
     const subject = getState().subject;
     const subject_dimensions = (subject && subject.imageMetadata) ? subject.imageMetadata : [];
     const classification = getState().classifications.classification;
-    const updatedAnnotations = (classification && classification.annotations) ? classification.annotations.slice() : [];  //Create a copy of the Annotations array so we can later update the Classification object with it.
+    const updatedAnnotations = [];  //Always start empty (don't pull anything from classification.annotation) the build the array based on the answers we have.
     const user = getState().login.user;
 
     //TODO: Better error handling

--- a/src/ducks/dialog.js
+++ b/src/ducks/dialog.js
@@ -1,6 +1,7 @@
 const initialState = {
  data: null,
- enableResize: true
+ enableResize: true,
+ isPrompt: false
 };
 
 const SET_POPUP = 'SET_POPUP';
@@ -10,7 +11,8 @@ const dialogReducer = (state = initialState, action) => {
    case SET_POPUP:
      return {
        data: action.dialog,
-       enableResize: action.resize
+       enableResize: action.resize,
+       isPrompt: action.isPrompt
      };
 
    default:
@@ -18,12 +20,13 @@ const dialogReducer = (state = initialState, action) => {
  };
 };
 
-const toggleDialog = (dialog, resize = true) => {
+const toggleDialog = (dialog, resize = true, isPrompt = false) => {
  return (dispatch) => {
    dispatch({
      type: SET_POPUP,
      dialog,
-     resize
+     resize,
+     isPrompt
    });
  };
 };

--- a/src/ducks/subject.js
+++ b/src/ducks/subject.js
@@ -53,7 +53,7 @@ const subjectReducer = (state = initialState, action) => {
         imageMetadata: [],
         status: SUBJECT_STATUS.READY,
         id: action.id,
-        queue: action.queue,
+        queue: action.queue || state.queue,
         favorite: action.favorite,
       });
 
@@ -165,7 +165,7 @@ const fetchSubject = (id = config.zooniverseLinks.workflowId, initialFetch = fal
     dispatch({
       type: FETCH_SUBJECT,
     });
-    
+
     //BETA_ONLY
     //----------------
     const subjectQuery = {
@@ -245,11 +245,30 @@ const prepareForNewSubject = (dispatch, subject) => {
   dispatch(changeFrame(0));
 };
 
+const fetchSavedSubject = (id) => {
+  return (dispatch) => {
+    apiClient.type('subjects').get(id)
+    .then((currentSubject) => {
+      dispatch(changeFrame(0));
+      dispatch({
+        type: FETCH_SUBJECT_SUCCESS,
+        favorite: currentSubject.favorite || false,
+        currentSubject, id,
+      });
+    })
+    .catch((err) => {
+      console.error(err);
+      dispatch({ type: FETCH_SUBJECT_ERROR });
+    })
+  };
+};
+
 export default subjectReducer;
 
 export {
   toggleFavorite,
   fetchSubject,
+  fetchSavedSubject,
   selectSubjectSet,
   setImageMetadata,
   SUBJECT_STATUS,

--- a/src/ducks/subject.js
+++ b/src/ducks/subject.js
@@ -163,7 +163,6 @@ const selectSubjectSet = (id) => {
  */
 const fetchSubject = (id = config.zooniverseLinks.workflowId, initialFetch = false) => {
   return (dispatch, getState) => {
-
     if (initialFetch && getState().subject.status !== SUBJECT_STATUS.IDLE) return;
 
     let savedClassificationPrompt = false;

--- a/src/styles/components/about-collection.styl
+++ b/src/styles/components/about-collection.styl
@@ -233,4 +233,3 @@
   .project-background
     background-image: url('../images/home-bg.jpg')
     height: 25em
-    top: 2em

--- a/src/styles/components/about-project.styl
+++ b/src/styles/components/about-project.styl
@@ -150,4 +150,3 @@
   .project-background
     background-image: url('../images/home-bg.jpg')
     height: 12em
-    top: 2em

--- a/src/styles/components/app-layout.styl
+++ b/src/styles/components/app-layout.styl
@@ -13,8 +13,9 @@ main
   background: url('../images/main-bg.jpg') no-repeat center center
   background-size: cover
   bottom: 0
+  height: 100%
   left: 0
   position: absolute
   right: 0
-  top: 0
+  top: 2em
   z-index: -1

--- a/src/styles/components/app-layout.styl
+++ b/src/styles/components/app-layout.styl
@@ -5,6 +5,7 @@
   display: flex
   flex-direction: column
   min-height: 100vh
+  position: relative
 
 main
   flex: 1 1 auto
@@ -13,7 +14,6 @@ main
   background: url('../images/main-bg.jpg') no-repeat center center
   background-size: cover
   bottom: 0
-  height: 100%
   left: 0
   position: absolute
   right: 0

--- a/src/styles/components/classification-prompt.styl
+++ b/src/styles/components/classification-prompt.styl
@@ -6,14 +6,30 @@
 
   h2
     @extend .secondary-head
+    text-align: center
 
   span
     @extend .body-copy
     display: block
-    margin: 3em 1em
+    margin: 2em 0.5em
+
+    i
+      font-weight: 700
 
   div
     text-align: center
 
-  button
-    margin: 1em
+    button
+      border: 1px solid $teal
+      font-size: 0.8em
+      margin: 2em 1em
+      padding: 1em 1.75em
+
+      &:hover, &:focus
+        background: $forest-green
+
+    button:nth-child(2)
+      background: $aqua-marine
+
+      &:hover, &:focus
+        background: $forest-green

--- a/src/styles/components/classification-prompt.styl
+++ b/src/styles/components/classification-prompt.styl
@@ -1,5 +1,32 @@
 @import "font-groups.styl"
 
+.save-confirm
+  @extend .body-copy
+  align-items: center
+  display: flex
+  flex-direction: column
+  font-size: 0.8em
+  justify-content: space-around
+  height: 100%
+  position: absolute
+
+  h3
+    @extend .secondary-head
+
+  span
+    margin: 0 2em
+    text-align: center
+
+  button
+    background-color: white
+    border: 1px solid $teal !important
+    margin: 1em
+    padding: 0.5em 2em
+    width: 6em
+
+    &:hover, &:focus
+      background-color: $teal
+
 .classification-prompt
   margin: 1em
   font-size: 0.8em

--- a/src/styles/components/classification-prompt.styl
+++ b/src/styles/components/classification-prompt.styl
@@ -1,0 +1,19 @@
+@import "font-groups.styl"
+
+.classification-prompt
+  margin: 1em
+  font-size: 0.8em
+
+  h2
+    @extend .secondary-head
+
+  span
+    @extend .body-copy
+    display: block
+    margin: 3em 1em
+
+  div
+    text-align: center
+
+  button
+    margin: 1em

--- a/src/styles/components/classifier-page.styl
+++ b/src/styles/components/classifier-page.styl
@@ -3,6 +3,10 @@
 .classifier-page
   padding: 1rem 0
 
+  .project-background
+    background-color: $sandy
+    background-image: none
+
   h2
     @extend .secondary-head
     display: inline

--- a/src/styles/components/submit-classification-form.styl
+++ b/src/styles/components/submit-classification-form.styl
@@ -1,53 +1,53 @@
 .submit-classification-form
   padding: 0 1em
   font-size: 0.8em
-  
+
   h2
     @extend .secondary-head
     font-weight: 600
     letter-spacing: 0.12em
     margin-bottom: 0
-  
+
   .tasks
     margin-bottom: 1.5em
-    
+
     .questions
       margin-bottom: 1em
-    
+
     .answers
       .single-answer
         display: block
         margin-top: 0.5em
         cursor: pointer
-        
+
         input[type=radio]
           margin-left: 0.5em
           margin-right: 1em
-  
+
   .action-buttons
     display: flex
     justify-content: center
     margin-bottom: 1em
-    
+
     button
       flex: 1 1 auto
       margin: 0 1em
       border-radius: 0
       font-size: 0.8em
       box-shadow: none
-      
+
       &:first-child
         margin-left: 0
-      
+
       &:last-child
         margin-right: 0
-      
+
       &.green.button
         border: none
-      
+
       &.white-green.button
         border: 1px solid $dark-grey
-      
+
       &.disabled.button
         background-color: $light-grey
         cursor: default


### PR DESCRIPTION
## PR Overview
This PR is the second attempt at adding the feature which allows logged-in users to _manually_ save all the Annotations they've done, and resume Classifying at a later date.

This feature was originally added in PR #164 but reverted in PR #180 . The reason:
- When a user attempts to Submit a Classification, they'd receive _Error: Could not submit Classification_ with the following console error:
  - `PUT https://panoptes-staging.zooniverse.org/api/classifications/89036 422 (Unprocessable Entity)`
  - `Submit classification: Error -  Error: {"schema"=>"did not contain a required property of 'annotations'"}`
  - Request payload is:
```
{  
  "http_cache":true,
  "classifications":{  
    "completed":true,
    "metadata":{  
      "session":"6365883a0a1763274133432875d9320dcdf51fe0fac064e1c88efa50b4b058e9",
      "started_at":"2017-11-23T13:13:20.249Z",
      "user_agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.94 Safari/537.36",
      "utc_offset":"0",
      "finished_at":"2017-11-23T14:57:22.642Z",
      "live_project":false,
      "user_language":"en",
      "user_group_ids":[  
        1326219
      ],
      "subject_dimensions":[  
        {  
          "naturalWidth":1962,
          "naturalHeight":1038,
          "clientWidth":1962,
          "clientHeight":1038
        }
      ],
      "workflow_version":"10.15",
      "viewport":{  
        "width":1363,
        "height":811
      }
    }
  }
}
```

This "second attempt" is intended to figure out wtf went wrong and fix the issue.

### Status
WIP