### PR TITLE
Update to New Header and Add Admin Prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "seven-ten": "^3.1.0",
     "zoo-grommet": "^0.2.1",
     "zooniverse-geordi-client": "^1.4.0",
-    "zooniverse-react-components": "github:zooniverse/Zooniverse-react-components#v0.6.3"
+    "zooniverse-react-components": "github:zooniverse/Zooniverse-react-components#v0.7.0"
   },
   "devDependencies": {
     "autoprefixer": "^6.5.3",

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,11 +1,9 @@
 import React from 'react';
-import { Link } from 'react-router';
-import { ZooHeader, LoginButton, LogoutButton, UserMenu } from 'zooniverse-react-components';
+import { ZooHeader } from 'zooniverse-react-components';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { loginToPanoptes, logoutFromPanoptes } from '../ducks/login';
 import AuthContainer from '../containers/AuthContainer';
-import SiteNavItems from '../lib/site-nav-items';
 
 class Header extends React.Component {
   constructor(props) {
@@ -23,14 +21,18 @@ class Header extends React.Component {
   }
 
   render() {
+    const isAdmin = this.props.user && this.props.user.admin;
+
     return (
-      <ZooHeader authContainer={<AuthContainer />} />
+      <ZooHeader authContainer={<AuthContainer />} isAdmin={isAdmin} />
     );
   }
 }
 
 Header.propTypes = {
+  dispatch: PropTypes.func,
   user: PropTypes.shape({
+    admin: PropTypes.bool,
     id: PropTypes.string,
   }),
 };
@@ -41,7 +43,7 @@ Header.defaultProps = {
 
 const mapStateToProps = (state) => {
   return {
-    user: state.login.user
+    user: state.login.user,
   };
 };
 


### PR DESCRIPTION
Zooniverse-React-Components updated the header component, so this PR makes those changes to the package.json

Notable changes include the addition of the `isAdmin` prop to the ZooHeader as well as the ability to toggle between mobile and desktop views.

There were also a few items being imported into the ASM header component that were unnecessary. 