### PR TITLE
Hover Message on Gray Line

### DIFF
--- a/src/components/AnnotationsPane.jsx
+++ b/src/components/AnnotationsPane.jsx
@@ -11,9 +11,9 @@ AnnotationsPane.jsx for details.
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Utility } from '../lib/Utility';
 import { connect } from 'react-redux';
 import { VisibilitySplit } from 'seven-ten';
+import { Utility } from '../lib/Utility';
 import PendingAnnotation from './PendingAnnotation';
 import { VARIANT_TYPES } from '../ducks/splits';
 import { MARKS_STATE } from '../ducks/subject-viewer';
@@ -32,7 +32,7 @@ class AnnotationsPane extends React.Component {
 
   render() {
     const pendingLine = this.props.mouseInViewer && this.props.annotationInProgress !== null;
-    const imageOffset = `translate(${-this.props.imageSize.width/2}, ${-this.props.imageSize.height/2})`;
+    const imageOffset = `translate(${-this.props.imageSize.width / 2}, ${-this.props.imageSize.height / 2})`;
     return (
       <g transform={imageOffset}>
         {pendingLine && (
@@ -50,8 +50,15 @@ class AnnotationsPane extends React.Component {
         {this.props.shownMarks !== MARKS_STATE.NONE && (
           this.renderUserAnnotations()
         )}
-        
+
         {this.renderAnnotationInProgress()}
+
+        <g ref={(el) => { this.tooltip = el; }} className="tooltip">
+          <rect x="15" y="-25" rx="10" ry="10" width="300" height="35" fill="#979797" />
+          <text x="28">
+            This line has been transcribed!
+          </text>
+        </g>
       </g>
     );
   }
@@ -69,14 +76,14 @@ class AnnotationsPane extends React.Component {
     for (let i = 0; i < this.props.annotationInProgress.points.length; i++) {
       const point = this.props.annotationInProgress.points[i];
 
-      if (i === this.props.annotationInProgress.points.length-1) {  //Final node: click to finish annotation.
+      if (i === this.props.annotationInProgress.points.length - 1) {  //Final node: click to finish annotation.
         svgPoints.push(
           <circle
             id="pulsating"
-            key={svgPointPrefix+i}
+            key={svgPointPrefix + i}
             cx={point.x} cy={point.y} r={10} fill="#00CED1"
             className="end"
-            style={{cursor: 'pointer'}}
+            style={{ cursor: 'pointer' }}
             onClick={(e) => {
               if (this.props.onCompleteAnnotation) {
                 this.props.onCompleteAnnotation();
@@ -89,26 +96,26 @@ class AnnotationsPane extends React.Component {
             onMouseUp={(e) => {
               return Utility.stopEvent(e);
             }}
-          />
+          />,
         );
       } else {
         svgPoints.push(
           <circle
-            key={svgPointPrefix+i}
+            key={svgPointPrefix + i}
             cx={point.x} cy={point.y} r={10} fill="#00CED1"
-          />
+          />,
         );
       }
 
       if (i > 0) {
-        const prevPoint = this.props.annotationInProgress.points[i-1];
+        const prevPoint = this.props.annotationInProgress.points[i - 1];
         svgLines.push(
           <line
-            key={svgLinePrefix+(i-1)}
+            key={svgLinePrefix + (i - 1)}
             x1={prevPoint.x} y1={prevPoint.y}
             x2={point.x} y2={point.y}
             stroke="#00CED1" strokeWidth="2"
-          />
+          />,
         );
       }
     }
@@ -118,12 +125,12 @@ class AnnotationsPane extends React.Component {
         <animate
           xlinkHref="#pulsating"
           attributeType="CSS" attributeName="opacity"
-          from="1" to="0.2" dur="1s" begin="0s"
+          from="1" to="0.2" dur="1s"
           begin="pulsating.mouseout"
           end="pulsating.mouseover"
           repeatCount="indefinite"
           fill="freeze"
-         />
+        />
         {svgLines}
         {svgPoints}
       </g>
@@ -171,24 +178,26 @@ class AnnotationsPane extends React.Component {
       if (annotation.frame !== this.props.frame) return null;
 
       let onSelectAnnotation = this.props.onSelectAnnotation;
-      let fillColor = previousAnnotations ? "#c33" : "#00CED1";
-      let style = { cursor: 'pointer' };
+      let consensusLine = false;
+      let fillColor = previousAnnotations ? '#c33' : '#00CED1';
+      const style = { cursor: 'pointer' };
 
       const selectedAnnotation = this.determineGreenLine(annotation, index);
 
-      if (selectedAnnotation) { fillColor = "#5cb85c"; }
+      if (selectedAnnotation) { fillColor = '#5cb85c'; }
       if (previousAnnotations && annotation.consensusReached) {
+        consensusLine = true;
         onSelectAnnotation = () => {};
-        fillColor = "#979797";
+        fillColor = '#979797';
         style.cursor = 'inherit';
       }
 
       let svgLinePrefix = `ANNOTATION_${index}_LINE_`;
       let svgPointPrefix = `ANNOTATION_${index}_POINT_`;
       if (previousAnnotations) {
-        svgLinePrefix = `PREVIOUS_` + svgLinePrefix;
-        svgPointPrefix = `PREVIOUS_` + svgPointPrefix;
-      };
+        svgLinePrefix = `PREVIOUS_${svgLinePrefix}`;
+        svgPointPrefix = `PREVIOUS_${svgPointPrefix}`;
+      }
       const svgLines = [];
       const svgPoints = [];
 
@@ -197,20 +206,20 @@ class AnnotationsPane extends React.Component {
 
         svgPoints.push(
           <circle
-            key={svgPointPrefix+i}
+            key={svgPointPrefix + i}
             cx={point.x} cy={point.y} r={10} fill={fillColor}
-          />
+          />,
         );
 
         if (i > 0) {
-          const prevPoint = annotation.points[i-1];
+          const prevPoint = annotation.points[i - 1];
           svgLines.push(
             <line
-              key={svgLinePrefix+(i-1)}
+              key={svgLinePrefix + (i - 1)}
               x1={prevPoint.x} y1={prevPoint.y}
               x2={point.x} y2={point.y}
               stroke={fillColor} strokeWidth="2"
-            />
+            />,
           );
         }
       }
@@ -223,6 +232,36 @@ class AnnotationsPane extends React.Component {
           onClick={(e) => {
             if (onSelectAnnotation) {
               onSelectAnnotation(index, previousAnnotations);
+            }
+            return Utility.stopEvent(e);
+          }}
+          onMouseOver={(e) => {
+            if (consensusLine) {
+              this.tooltip.style.visibility = 'visible';
+            }
+            return Utility.stopEvent(e);
+          }}
+          onMouseOut={(e) => {
+            if (consensusLine) {
+              this.tooltip.style.visibility = 'hidden';
+            }
+            return Utility.stopEvent(e);
+          }}
+          onMouseMove={(e) => {
+            if (consensusLine) {
+              const cursor = this.props.getPointerXY(e);
+              let rotationOffset;
+              switch (this.props.rotation) {
+                case 90:
+                  rotationOffset = 270;
+                  break;
+                case 270:
+                  rotationOffset = 90;
+                  break;
+                default:
+                  rotationOffset = this.props.rotation;
+              }
+              this.tooltip.setAttribute('transform', `translate(${cursor.x}, ${cursor.y}) rotate(${rotationOffset})`);
             }
             return Utility.stopEvent(e);
           }}
@@ -242,13 +281,17 @@ class AnnotationsPane extends React.Component {
 
       if (this.props.variant === VARIANT_TYPES.COLLABORATIVE && previousAnnotations) {
         return (
-          <VisibilitySplit key={annotationPrefix + index} splits={this.props.splits} splitKey={'classifier.collaborative'} elementKey={'div'}>
+          <VisibilitySplit
+            key={annotationPrefix + index}
+            splits={this.props.splits}
+            splitKey={'classifier.collaborative'}
+            elementKey={'div'}
+          >
             {renderedMarks}
           </VisibilitySplit>
-        )
-      } else {
-        return renderedMarks
+        );
       }
+      return renderedMarks;
     });
   }
 }
@@ -279,24 +322,27 @@ AnnotationsPane.propTypes = {
         x: PropTypes.number,
         y: PropTypes.number,
       })),
-    })
+    }),
   ),
-  frame: PropTypes.number,
+  rotation: PropTypes.number,
+  getPointerXY: PropTypes.func,
+  mouseInViewer: PropTypes.bool,
   previousAnnotations: PropTypes.arrayOf(PropTypes.object),
   selectedAnnotation: PropTypes.shape({
-    previousAnnotation: PropTypes.bool
+    previousAnnotation: PropTypes.bool,
   }),
   selectedAnnotationIndex: PropTypes.number,
   shownMarks: PropTypes.number,
-  splits: PropTypes.object,
-  variant: PropTypes.string
+  splits: PropTypes.shape({
+    data: PropTypes.object,
+  }),
+  variant: PropTypes.string,
 };
 
 AnnotationsPane.defaultProps = {
   frame: 0,
   onCompleteAnnotation: null,
   onSelectAnnotation: null,
-  frame: 0,
   //--------
   imageSize: {
     width: 0,
@@ -306,25 +352,27 @@ AnnotationsPane.defaultProps = {
   adminOverride: false,
   annotationInProgress: null,
   annotations: [],
+  rotation: 0,
   previousAnnotations: [],
   selectedAnnotation: {
-    previousAnnotation: false
+    previousAnnotation: false,
   },
   selectedAnnotationIndex: 0,
   shownMarks: 0,
   splits: null,
-  variant: VARIANT_TYPES.INDIVIDUAL
+  variant: VARIANT_TYPES.INDIVIDUAL,
 };
 
 const mapStateToProps = (state) => {
   return {
     adminOverride: state.splits.adminOverride,
     frame: state.subjectViewer.frame,
+    rotation: state.subjectViewer.rotation,
     selectedAnnotation: state.annotations.selectedAnnotation,
     selectedAnnotationIndex: state.annotations.selectedAnnotationIndex,
     shownMarks: state.subjectViewer.shownMarks,
     splits: state.splits.data,
-    variant: state.splits.variant
+    variant: state.splits.variant,
   };
 };
 

--- a/src/containers/SubjectViewer.jsx
+++ b/src/containers/SubjectViewer.jsx
@@ -192,7 +192,7 @@ class SubjectViewer extends React.Component {
     //Make sure we monitor visible size of Subject Viewer.
     window.addEventListener('resize', this.updateSize);
     this.updateSize();
-    
+
     //Fetch the first subject, IF no subject has yet been loaded.
     //Fetching a subject will also ensure a clean slate for Annotations,
     //Previous Annotations, and Classifications.

--- a/src/styles/components/subject-viewer.styl
+++ b/src/styles/components/subject-viewer.styl
@@ -8,6 +8,9 @@
     background: $light-grey
     border: 1px solid #fff  //TMP: Borders offer visual differentiation but may interfere with precise mathematical calculations of width.
 
+.tooltip
+  visibility: hidden
+
 .filmstrip-viewer
   position: relative
 


### PR DESCRIPTION
This branch is working, but there are a couple questions lingering during the review:

Currently, a user will not have a mouse down event over a previous annotation when in navigating or annotating mode. If this appears to throw off the user, I can pass those functions into a child prop to replicate their functionality. Just something to take note of during review.

Also made some line changes to appease the linter.

Closes #176 