### PR TITLE
Add Header to Dialogs

### DIFF
--- a/src/components/Dialog.jsx
+++ b/src/components/Dialog.jsx
@@ -18,6 +18,19 @@ class Dialog extends React.Component {
     // }
   }
 
+  stopEvent(e) {
+    e.preventDefault && e.preventDefault();
+    e.stopPropagation && e.stopPropagation();
+    e.returnValue = false;
+    e.cancelBubble = true;
+    return false;
+  }
+
+  close(e) {
+    this.onClose();
+    return this.stopEvent(e);
+  }
+
   render() {
     const width = this.props.isPrompt ? 450 : 800;
     const height = 425;
@@ -26,7 +39,7 @@ class Dialog extends React.Component {
 
     const defaultPosition = { x, y, height, width };
     const enableResize = this.props.enableResize ? { bottomRight: true } : false;
-    const resizeClass = this.props.enableResize ? { bottomRight: "drag-handler" } : false;
+    const resizeClass = this.props.enableResize ? { bottomRight: 'drag-handler' } : false;
     const children = React.Children.map(this.props.children, (child) => {
       return React.cloneElement(child, { onClose: this.close });
     });
@@ -41,44 +54,41 @@ class Dialog extends React.Component {
       >
         <div className="popup dialog" ref={(c)=>{this.popupBody=c}} onClick={(e) => { return e.target === this.popupBody && this.close(e); }}>
           <div className="popup-content dialog-content">
-            {!this.props.isPrompt && (
-              <button className="close-button" onClick={this.close}>X</button>
-            )}
+            <div>
+              {this.props.title.length ? (
+                <h2>{this.props.title}</h2>
+              ) : false}
+
+              {!this.props.isPrompt && (
+                <button className="close-button" onClick={this.close}>X</button>
+              )}
+            </div>
             {children}
           </div>
         </div>
       </Rnd>
     );
   }
-
-  close(e) {
-    this.onClose();
-    return this.stopEvent(e);
-  }
-
-  stopEvent(e) {
-    e.preventDefault && e.preventDefault();
-    e.stopPropagation && e.stopPropagation();
-    e.returnValue = false;
-    e.cancelBubble = true;
-    return false;
-  }
 }
 
 Dialog.defaultProps = {
   enableResize: true,
-  isPrompt: false
-}
+  isPrompt: false,
+  title: '',
+};
 
 Dialog.propTypes = {
+  children: PropTypes.node,
   dispatch: PropTypes.func,
   enableResize: PropTypes.bool,
-  isPrompt: PropTypes.bool
-}
+  isPrompt: PropTypes.bool,
+  title: PropTypes.string,
+};
 
 const mapStateToProps = (state) => ({
   enableResize: state.dialog.enableResize,
-  isPrompt: state.dialog.isPrompt
+  isPrompt: state.dialog.isPrompt,
+  title: state.dialog.title,
 });
 
 export default connect(mapStateToProps)(Dialog);

--- a/src/components/FieldGuide.jsx
+++ b/src/components/FieldGuide.jsx
@@ -81,7 +81,7 @@ class FieldGuide extends React.Component {
 
     return (
       <div className="active-card">
-        <button className="field-guide-title" onClick={this.deactivateCard}>
+        <button onClick={this.deactivateCard}>
           <i className="fa fa-arrow-left" /> Back
         </button>
 

--- a/src/components/FieldGuide.jsx
+++ b/src/components/FieldGuide.jsx
@@ -109,7 +109,6 @@ class FieldGuide extends React.Component {
   render() {
     return (
       <div>
-        <p className="field-guide-title">Field Guide</p>
         {this.state.activeCard && (this.renderActiveCard())}
 
         {!this.state.activeCard && (

--- a/src/components/ShowMetadata.jsx
+++ b/src/components/ShowMetadata.jsx
@@ -5,7 +5,6 @@ import Divider from '../images/img_divider.png';
 const ShowMetadata = ({ metadata }) => {
   return (
     <div className="show-metadata">
-      <h2>Subject Info</h2>
       <img role="presentation" className="divider" src={Divider} />
       <table width="100%">
         {Object.keys(metadata).map((key, i) => {

--- a/src/containers/ClassifierContainer.jsx
+++ b/src/containers/ClassifierContainer.jsx
@@ -235,12 +235,12 @@ class ClassifierContainer extends React.Component {
             {this.state.popup}
           </Popup>
         }
-        
+
         { /*BETA_ONLY: Show sign in prompt to users who haven't signed in.*/
         (!(this.props.initialised && !this.props.user && this.state.showBetaSignInPrompt)) ? null :
           <Popup className="beta-popup-sign-in-prompt" onClose={()=>{ this.setState({ showBetaSignInPrompt: false }); }}>
             <div>
-              Thanks for participating in our beta test. 
+              Thanks for participating in our beta test.
               Before you begin transcribing, please sign in or create an account by clicking the button below:
             </div>
             <div>
@@ -317,7 +317,7 @@ class ClassifierContainer extends React.Component {
 
   showMetadata() {
     this.props.dispatch(toggleDialog(
-      <ShowMetadata metadata={this.props.currentSubject.metadata} />));
+      <ShowMetadata metadata={this.props.currentSubject.metadata} />, true, false, 'Subject Info'));
   }
 
   toggleFieldGuide() {
@@ -326,7 +326,7 @@ class ClassifierContainer extends React.Component {
     }
 
     this.props.dispatch(toggleDialog(
-      <FieldGuide guide={this.props.guide} icons={this.props.icons} />, false));
+      <FieldGuide guide={this.props.guide} icons={this.props.icons} />, false, false, 'Field Guide'));
   }
 
   showTutorial() {
@@ -352,6 +352,7 @@ ClassifierContainer.propTypes = {
   adminOverride: PropTypes.bool,
   currentSubject: PropTypes.shape({
     id: PropTypes.string,
+    metadata: PropTypes.object,
   }),
   dispatch: PropTypes.func,
   goldStandardMode: PropTypes.bool,

--- a/src/ducks/dialog.js
+++ b/src/ducks/dialog.js
@@ -1,38 +1,40 @@
 const initialState = {
- data: null,
- enableResize: true,
- isPrompt: false
+  data: null,
+  enableResize: true,
+  isPrompt: false,
 };
 
 const SET_POPUP = 'SET_POPUP';
 
 const dialogReducer = (state = initialState, action) => {
- switch (action.type) {
-   case SET_POPUP:
-     return {
-       data: action.dialog,
-       enableResize: action.resize,
-       isPrompt: action.isPrompt
-     };
+  switch (action.type) {
+    case SET_POPUP:
+      return {
+        data: action.dialog,
+        enableResize: action.resize,
+        isPrompt: action.isPrompt,
+        title: action.title,
+      };
 
-   default:
-     return state;
- };
+    default:
+      return state;
+  }
 };
 
-const toggleDialog = (dialog, resize = true, isPrompt = false) => {
- return (dispatch) => {
-   dispatch({
-     type: SET_POPUP,
-     dialog,
-     resize,
-     isPrompt
-   });
- };
+const toggleDialog = (dialog, resize = true, isPrompt = false, title = '') => {
+  return (dispatch) => {
+    dispatch({
+      type: SET_POPUP,
+      dialog,
+      resize,
+      isPrompt,
+      title,
+    });
+  };
 };
 
 export default dialogReducer;
 
 export {
- toggleDialog
+  toggleDialog,
 };

--- a/src/styles/components/collections-manager.styl
+++ b/src/styles/components/collections-manager.styl
@@ -22,6 +22,7 @@
 
 .collections-manager
   font-size: 0.7em
+  margin: 1.5em
 
   &__error
     color: red
@@ -60,6 +61,9 @@
 
     > *
       flex: 1 0 auto
+
+    input
+      margin-right: 0.25em
 
     .submit-button-container
       text-align: right

--- a/src/styles/components/field-guide.styl
+++ b/src/styles/components/field-guide.styl
@@ -5,6 +5,7 @@
   display: flex
   flex-wrap: wrap
   height: 100%
+  margin-top: 3em
   width: 100%
 
   div
@@ -16,6 +17,7 @@
       background: $dark-grey
       display: flex
       flex-direction: column
+      margin: auto
       padding: 0
 
     span
@@ -31,13 +33,6 @@
     height: 4.5em
     width: 6.5em
     object-fit: cover
-
-.field-guide-title
-  font-family: $playfair-display
-  font-size: 0.75em
-  letter-spacing: 0.25em
-  margin-bottom: 1em
-  text-transform: uppercase
 
 .active-card
   button

--- a/src/styles/components/popup.styl
+++ b/src/styles/components/popup.styl
@@ -36,9 +36,26 @@
   .close-button
     font-family: $playfair-display
     font-size: 0.75em
+    padding: 1em
 
   .dialog-content
     min-height: 100%
+
+    > div:first-child
+      background-color: white
+      box-shadow: 3px 3px 3px $mid-grey
+      position: fixed
+      width: 100%
+      z-index: 1
+
+    h2
+      display: inline-block
+      font-family: $playfair-display
+      font-size: 0.75em
+      font-weight: 300
+      letter-spacing: 0.25em
+      margin: 1em
+      text-transform: uppercase
 
     button
       color: black
@@ -56,7 +73,6 @@
     background: $white
     color: $text-color
     overflow: auto
-    padding: 0.5em 1em
 
   button
     border: none

--- a/src/styles/components/show-metadata.styl
+++ b/src/styles/components/show-metadata.styl
@@ -2,6 +2,7 @@
   align-items: center
   display: flex
   flex-direction: column
+  margin-top: 3em
   padding: 0 2em 4em 2em
 
   table
@@ -27,6 +28,7 @@
 
   td:first-child
     text-align: right
+    width: 33%
 
   td:nth-child(2)
     letter-spacing: 0.05em

--- a/src/styles/components/show-metadata.styl
+++ b/src/styles/components/show-metadata.styl
@@ -12,13 +12,6 @@
   .divider
     margin: 0.5em auto 1em auto
 
-  h2
-    @extend .secondary-head
-    font-size: 0.8em
-    font-weight: 600
-    letter-spacing: 0.12em
-    margin-bottom: 0
-
   td
     @extend .secondary-head
     line-height: 1.75em

--- a/src/styles/components/submit-classification-form.styl
+++ b/src/styles/components/submit-classification-form.styl
@@ -1,5 +1,5 @@
 .submit-classification-form
-  padding: 0 1em
+  padding: 1em 2em
   font-size: 0.8em
 
   h2


### PR DESCRIPTION
Not all headers are given a dialog (such as simple popups). However, the main use case here was the give the metadata popup a distinct header that stood out and stayed at the top when scrolling.

Additional line changes were made to keep the linter uniform.

<img width="818" alt="classifier" src="https://user-images.githubusercontent.com/14099077/33291419-64350abe-d38b-11e7-9a95-4f57c5606b2c.png">
