### PR TITLE
Remove Workflow Config from Previous Annotations and Subject Ducks

### DIFF
--- a/src/containers/SubjectViewer.jsx
+++ b/src/containers/SubjectViewer.jsx
@@ -192,12 +192,11 @@ class SubjectViewer extends React.Component {
     //Make sure we monitor visible size of Subject Viewer.
     window.addEventListener('resize', this.updateSize);
     this.updateSize();
-    
+
     //Fetch the first subject, IF no subject has yet been loaded.
     //Fetching a subject will also ensure a clean slate for Annotations,
     //Previous Annotations, and Classifications.
     this.props.dispatch(fetchSubject(
-      undefined,  //JS Quirk: this ensures we're fetching the default value for the 'id' parameter (as defined in fetchSubject())
       true,  //Initial fetch only, meaning ignore this action call if a Subject is already being fetch/has already been loaded.
     ));
   }

--- a/src/ducks/previousAnnotations.js
+++ b/src/ducks/previousAnnotations.js
@@ -96,18 +96,19 @@ const previousAnnotationsReducer = (state = initialState, action) => {
 
 const fetchPreviousAnnotations = (subject) => {
   if (!subject) return () => {};
-
-  const query = `{
-    workflow(id: ${config.zooniverseLinks.workflowId}) {
-      reductions(subjectId: ${subject.id}) {
-        data
-      }
-    }
-  }`;
-
   return (dispatch, getState) => {
+    const workflowId = getState().workflow.id;
+
+    const query = `{
+      workflow(id: ${workflowId}) {
+        reductions(subjectId: ${subject.id}) {
+          data
+        }
+      }
+    }`;
+
     dispatch({
-      type: FETCH_ANNOTATIONS
+      type: FETCH_ANNOTATIONS,
     });
 
     request(config.zooniverseLinks.caesarHost, query).then((data) => {

--- a/src/ducks/subject.js
+++ b/src/ducks/subject.js
@@ -169,9 +169,10 @@ const selectSubjectSet = (id) => {
     meant to be the first fetchSubject of the user's session. Hence, the Subject
     will ONLY be fetched IF no Subject has previously been fetched.
  */
-const fetchSubject = (id = config.zooniverseLinks.workflowId, initialFetch = false) => {
+const fetchSubject = (initialFetch = false) => {
   return (dispatch, getState) => {
     if (initialFetch && getState().subject.status !== SUBJECT_STATUS.IDLE) return;
+    const workflow_id = getState().workflow.id;
 
     let savedClassificationPrompt = false;
     const user = getState().login.user;
@@ -189,7 +190,7 @@ const fetchSubject = (id = config.zooniverseLinks.workflowId, initialFetch = fal
     //BETA_ONLY
     //----------------
     let subjectQuery = {
-      workflow_id: id,
+      workflow_id,
       subject_set_id: config.zooniverseLinks.betaSubjectSet,
     };
 


### PR DESCRIPTION
This PR fixes the bugs that currently exist with two ducks using the config file for the default individual workflow. Instead of discerning which variant a user is placed (individual/collaborative), the config always defaults to the individual workflow.

I'd like to figure out why Caesar is sending a 404 before this is merged.