### PR TITLE
Retired Annotation Lines don't eat mouse events, plus stopEvent improvements

### DIFF
--- a/src/components/AnnotationsPane.jsx
+++ b/src/components/AnnotationsPane.jsx
@@ -233,17 +233,21 @@ class AnnotationsPane extends React.Component {
             if (onSelectAnnotation) {
               onSelectAnnotation(index, previousAnnotations);
             }
+
+            if (consensusLine) return;  //If retired line, don't stop events.
             return Utility.stopEvent(e);
           }}
           onMouseOver={(e) => {
             if (consensusLine) {
               this.tooltip.style.visibility = 'visible';
+              return;  //If retired line, don't stop events.
             }
             return Utility.stopEvent(e);
           }}
           onMouseOut={(e) => {
             if (consensusLine) {
               this.tooltip.style.visibility = 'hidden';
+              return;  //If retired line, don't stop events.
             }
             return Utility.stopEvent(e);
           }}
@@ -262,13 +266,16 @@ class AnnotationsPane extends React.Component {
                   rotationOffset = this.props.rotation;
               }
               this.tooltip.setAttribute('transform', `translate(${cursor.x}, ${cursor.y}) rotate(${rotationOffset})`);
+              return;  //If retired line, don't stop events.
             }
             return Utility.stopEvent(e);
           }}
           onMouseDown={(e) => {  //Prevent triggering actions in the parent SubjectViewer.
+            if (consensusLine) return;  //If retired line, don't stop events.
             return Utility.stopEvent(e);
           }}
           onMouseUp={(e) => {
+            if (consensusLine) return;  //If retired line, don't stop events.
             return Utility.stopEvent(e);
           }}
         >

--- a/src/components/Dialog.jsx
+++ b/src/components/Dialog.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import Rnd from 'react-rnd';
 import { connect } from 'react-redux';
 import { toggleDialog } from '../ducks/dialog';
+import { Utility } from '../lib/Utility';
 
 class Dialog extends React.Component {
   constructor(props) {
@@ -18,17 +19,9 @@ class Dialog extends React.Component {
     // }
   }
 
-  stopEvent(e) {
-    e.preventDefault && e.preventDefault();
-    e.stopPropagation && e.stopPropagation();
-    e.returnValue = false;
-    e.cancelBubble = true;
-    return false;
-  }
-
   close(e) {
     this.onClose();
-    return this.stopEvent(e);
+    return Utility.stopEvent(e);
   }
 
   render() {

--- a/src/components/Popup.jsx
+++ b/src/components/Popup.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Utility } from '../lib/Utility';
 
 class Popup extends React.Component {
   constructor(props) {
@@ -23,15 +24,7 @@ class Popup extends React.Component {
 
   close(e) {
     this.props.onClose && this.props.onClose();
-    return this.stopEvent(e);
-  }
-
-  stopEvent(e) {
-    e.preventDefault && e.preventDefault();
-    e.stopPropagation && e.stopPropagation();
-    e.returnValue = false;
-    e.cancelBubble = true;
-    return false;
+    return Utility.stopEvent(e);
   }
 }
 


### PR DESCRIPTION
## PR Overview
This PR makes some minor improvements to how we code Events.
- Retired Annotation Lines no longer eat mouse events, meaning we can now Pan (and Annotate)
 actions work when the mouse is over these greyed-out lines. (see PR #185 )
- Dialog and Popup both had their own versions of stopEvent(), which is actually a shared function available by the lib/Utility object. This PR standardises the use of stopEvent() in both components.

### Status
Ready for review.