### PR TITLE
Fix 173 - Add safeties to getSubjectLocation() to prevent "Could not submit Classification" error

### DIFF
--- a/src/components/SocialSection.jsx
+++ b/src/components/SocialSection.jsx
@@ -14,7 +14,7 @@ const SocialSection = ({ project, subjectsOfNote }) =>
 
           {subjectsOfNote.map((subject, i) => {
             const location = getSubjectLocation(subject);
-            const thumbnail = getThumbnailSource(location.src);
+            const thumbnail = (location && location.src) ? getThumbnailSource(location.src) : undefined;
             return (
               <div key={i}>
                 <img src={thumbnail} />

--- a/src/containers/Navigator.jsx
+++ b/src/containers/Navigator.jsx
@@ -81,7 +81,10 @@ class Navigator extends React.Component {
     const transform = `translate(${-this.props.translationX * this.props.scaling}, ${-this.props.translationY * this.props.scaling})`;
     const rotate = `rotate(${this.props.rotation})`;
     let subjectLocation;
-    if (this.props.currentSubject) subjectLocation = getSubjectLocation(this.props.currentSubject, this.props.frame).src;
+    if (this.props.currentSubject) {
+      subjectLocation = getSubjectLocation(this.props.currentSubject, this.props.frame);
+      subjectLocation = (subjectLocation && subjectLocation.src) ? subjectLocation.src : undefined;
+    };
 
     return (
       <section className="navigator-viewer" ref={(c) => { this.section = c; }}>

--- a/src/containers/SubjectViewer.jsx
+++ b/src/containers/SubjectViewer.jsx
@@ -106,7 +106,10 @@ class SubjectViewer extends React.Component {
     let subjectLocation = undefined;
     const cursor = this.props.viewerState === SUBJECTVIEWER_STATE.NAVIGATING ? 'cursor-move' : 'cursor-crosshairs';
 
-    if (this.props.currentSubject) subjectLocation = getSubjectLocation(this.props.currentSubject, this.props.frame).src;
+    if (this.props.currentSubject) {
+      subjectLocation = getSubjectLocation(this.props.currentSubject, this.props.frame);
+      subjectLocation = (subjectLocation && subjectLocation.src) ? subjectLocation.src : undefined;
+    };
 
     return (
       <section className={`subject-viewer ${cursor}`} ref={(c)=>{this.section=c}}>

--- a/src/lib/get-subject-location.js
+++ b/src/lib/get-subject-location.js
@@ -6,9 +6,13 @@ function getSubjectLocation(subject, frame = 0) {
   let format;
   let type;
   let src;
-
-  const currentLocation = subject.locations[frame];
-
+  
+  const currentLocation = (subject && subject.locations) ? subject.locations[frame] : undefined;
+  
+  //When transitioning e.g. from a Subject with 5 pages to a Subject with 2
+  //pages, an error will occur if the page viewer is still set to page 5.
+  if (!currentLocation) return undefined;
+  
   Object.keys(currentLocation).some((mimeType) => {
     src = currentLocation[mimeType];
     [type, format] = mimeType.split('/');


### PR DESCRIPTION
## PR Review
Fixes #173 

When submitting Classifications - notably of extremely long documents - users will sometimes encounter "Could not submit Classification" errors.

The root issue is that, when a user is, e.g. viewing Page 5 of a 5-page document, then submits, and the next document is only 2 pages, we get an array-out-of-bounds error that chains into a null reference error that triggers the "Could not submit Classification" error. (The Classification is actually submitted, incidentally.)

This PR adds strict checks around the point of error - `getSubjectLocation()` - and adds a nigh paranoid amount of checks to prevent null objects from ruining anyone's day.

![screen shot 2017-11-29 at 13 07 46](https://user-images.githubusercontent.com/13952701/33387895-5e430f7e-d526-11e7-80c5-76a752ff5c9f.png)
_An example of the error in action. The error occurs right after I initiate the Submit Classification action, while I'm looking at page 5. The next Subject in the queue, surely enough, had only 2 pages._

### Dev Notes
I originally wanted to add a simple `resetViewer()` call before/at the start of each `fetchSubject()` call, to ensure the first `getSubjectLocation()` after a fetchSubject would always refer to Page 1. (i.e. index 0, which almost every Subject should have.)

However, there were two issues with this:
1. The timing for the dispatch(resetViewer()) is tricky; the "proper" way would involve chaining these calls into a bunch of nested `.then()`s and that'd get messy real quick.
2. The resetViewer() solution would still encounter issues with Subjects with 0 images, anyhoo.

Curiously, while this particular solution ensures `getSubjectLocation()` returns an `undefined` when it's given an invalid subject+index (e.g. 2-page Subject, index 4), we _don't actually see_ an empty page during the transition between Subjects.

Turns out we have so many data store updates/renders per second during the fetchSubject()/get next Subject process that the "blank page" (from when getSubjectLocation returns undefined) only exists for a nanosecond before being replaced with a valid page.

### Status
This PR is ready for review, @wgranger 👍 

