### PR TITLE
Functioning SVG Subject Loading Spinner

### DIFF
--- a/src/components/LoadingSpinner.jsx
+++ b/src/components/LoadingSpinner.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 class LoadingSpinner extends React.Component {
   render() {

--- a/src/components/SVGImage.jsx
+++ b/src/components/SVGImage.jsx
@@ -29,6 +29,7 @@ AnnotationsPane.jsx for details.
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import SubjectLoading from './SubjectLoading';
 
 const FILTER = "url('#svg-invert-filter')"
 
@@ -73,7 +74,8 @@ export default class SVGImage extends React.Component {
 
     if (this.state.loaded) {
       return (
-        <image className="svg-image"
+        <image
+          className="svg-image"
           style={invertFilter}
           xlinkHref={this.image.src}
           width={this.image.width}
@@ -89,11 +91,8 @@ export default class SVGImage extends React.Component {
           <path d="M -60 -80 L 0 -20 L 60 -80 L 80 -60 L 20 0 L 80 60 L 60 80 L 0 20 L -60 80 L -80 60 L -20 0 L -80 -60 Z" />
         </g>
       );
-    } else {
-      return (
-        <circle className="svg-image-loading" cx={0} cy={0} r={100} />
-      );
     }
+    return <SubjectLoading />;
   }
 }
 

--- a/src/components/SVGImage.jsx
+++ b/src/components/SVGImage.jsx
@@ -92,7 +92,7 @@ export default class SVGImage extends React.Component {
         </g>
       );
     }
-    return <SubjectLoading />;
+    return <SubjectLoading loaded={this.state.loaded} />;
   }
 }
 

--- a/src/components/SubjectLoading.jsx
+++ b/src/components/SubjectLoading.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const SubjectLoading = ({ loaded }) => {
+  const transform = !loaded ? 'scale(0.35)' : '';
+
+  return (
+    <g id="Already-Seen-/-messaging" transform={transform} stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
+      <g id="first-annotation" transform="scale(3) translate(-15, -50)" strokeWidth="2">
+        <g id="Group">
+          <circle id="Oval-2" stroke="#C4AFB9" cx="15" cy="15" r="15" />
+          <path
+            d="M15,30 C23.2842712,30 30,23.2842712 30,15
+              C30,6.71572875 23.2842712,0 15,0
+              C6.71572875,0 0,6.71572875 0,15"
+            id="Oval-2"
+            stroke="#7B5A69"
+          />
+          <animateTransform
+            attributeName="transform"
+            type="rotate"
+            from="0 15 15"
+            to="360 15 15"
+            dur="0.5s"
+            repeatCount="indefinite"
+          />
+        </g>
+      </g>
+      <text
+        className="subject-loading-spinner"
+        x="0" y="80" fill="#4a4a4a"
+        fontFamily="Playfair Display"
+        fontSize="40" textAnchor="middle"
+      >
+          SUBJECT LOADING
+      </text>
+      <line
+        x1="-80" y1="150" x2="80" y2="150"
+        strokeWidth="4px" stroke="#979797"
+      />
+    </g>
+  );
+};
+
+SubjectLoading.propTypes = {
+  loaded: PropTypes.bool,
+};
+
+SubjectLoading.defaultProps = {
+  loaded: false,
+};
+
+export default SubjectLoading;

--- a/src/containers/SubjectViewer.jsx
+++ b/src/containers/SubjectViewer.jsx
@@ -21,7 +21,6 @@ AnnotationsPane.jsx for details.
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import FilmstripViewer from '../components/FilmstripViewer';
 import SVGImage from '../components/SVGImage';
 import AnnotationsPane from '../components/AnnotationsPane';
 import ZoomTools from '../components/ZoomTools';
@@ -31,20 +30,20 @@ import { getSubjectLocation } from '../lib/get-subject-location';
 import SelectedAnnotation from '../components/SelectedAnnotation';
 
 import {
-  setRotation, setScaling, setTranslation, resetView,
+  setScaling, setTranslation, resetView,
   setViewerState, updateViewerSize, updateImageSize,
   SUBJECTVIEWER_STATE,
 } from '../ducks/subject-viewer';
 
 import {
   addAnnotationPoint, completeAnnotation, selectAnnotation,
-  unselectAnnotation, ANNOTATION_STATUS
+  unselectAnnotation, ANNOTATION_STATUS,
 } from '../ducks/annotations';
 
 const INPUT_STATE = {
   IDLE: 0,
   ACTIVE: 1,
-}
+};
 
 const ZOOM_STEP = 0.1;
 const MAX_ANGLE = 8;
@@ -109,7 +108,7 @@ class SubjectViewer extends React.Component {
     if (this.props.currentSubject) {
       subjectLocation = getSubjectLocation(this.props.currentSubject, this.props.frame);
       subjectLocation = (subjectLocation && subjectLocation.src) ? subjectLocation.src : undefined;
-    };
+    }
 
     return (
       <section className={`subject-viewer ${cursor}`} ref={(c)=>{this.section=c}}>

--- a/src/ducks/classifications.js
+++ b/src/ducks/classifications.js
@@ -220,7 +220,7 @@ const retrieveClassification = (id) => {
   return (dispatch) => {
     apiClient.type('classifications/incomplete').get({ id })
       .then(([classification]) => {
-        //TODO: Test if classification.annotations.shift() is OK; normally we don't update the classification object directly. 
+        //TODO: Test if classification.annotations.shift() is OK; normally we don't update the classification object directly.
         const subjectId = classification.links.subjects.shift();
         const annotations = classification.annotations.shift();
         dispatch(setAnnotations(annotations.value));
@@ -269,7 +269,7 @@ const saveClassificationInProgress = () => {
         localStorage.setItem(`${user.id}.classificationID`, savedClassification.id);
       }
       dispatch(toggleDialog(<SaveSuccess />, false, true));
-      
+
       //Refresh our Classification object with the newer, fresher version from
       //Panoptes. If we don't, all future .save() and .update() actions on the
       //(old) Classification object will start going wonky.

--- a/src/styles/components/subject-viewer.styl
+++ b/src/styles/components/subject-viewer.styl
@@ -83,6 +83,9 @@
     position: absolute
     width: 100%
 
+.subject-loading-spinner
+  letter-spacing: 0.5em
+
 //TODO: review loading and error indicators.
 
 .svg-image-loading


### PR DESCRIPTION
This PR places an SVG loading spinner in place of the previous pulsating circle. 

As always, a couple additional lines were modified per the linter's suggestions.

Closes #137 

![screen shot 2017-11-30 at 11 38 24 am](https://user-images.githubusercontent.com/14099077/33445664-1ece7a84-d5c3-11e7-889c-89190f4ec7a2.png)
