### PR TITLE
Adjust Margin and Font Size in Classifier

### DIFF
--- a/src/styles/components/classifier-page.styl
+++ b/src/styles/components/classifier-page.styl
@@ -32,7 +32,6 @@
 
     .help-buttons
       font-family: $sans-font
-      margin-top: 2em
 
       .divider
         width: 8em

--- a/src/styles/components/project-header.styl
+++ b/src/styles/components/project-header.styl
@@ -6,7 +6,7 @@
 
   .main-title
     flex: 1
-    font-size 2.5rem
+    font-size 1.7rem
 
   &__nav
     align-self: flex-start


### PR DESCRIPTION
Sorry. Two small items I forgot to adjust with the design updates branch from earlier. These changes are based on the image below.

<img width="1278" alt="anti-slavery_manuscripts_and_slack_-_zooniverse" src="https://user-images.githubusercontent.com/14099077/34061791-50711856-e1af-11e7-80bb-15b1526ac438.png">
