### PR TITLE
Convert to "Single Line" Annotations

### DIFF
--- a/src/components/AnnotationsPane.jsx
+++ b/src/components/AnnotationsPane.jsx
@@ -37,7 +37,6 @@ class AnnotationsPane extends React.Component {
       <g transform={imageOffset}>
         {pendingLine && (
           <PendingAnnotation
-            angleDegree={this.props.angleDegree}
             annotationInProgress={this.props.annotationInProgress}
             getPointerXY={this.props.getPointerXY}
             mouseInViewer={this.props.mouseInViewer}
@@ -314,7 +313,6 @@ AnnotationsPane.propTypes = {
   }),
   //--------
   adminOverride: PropTypes.bool,
-  angleDegree: PropTypes.func,
   annotationInProgress: PropTypes.shape({
     text: PropTypes.string,
     points: PropTypes.arrayOf(PropTypes.shape({

--- a/src/components/AnnotationsPane.jsx
+++ b/src/components/AnnotationsPane.jsx
@@ -75,36 +75,12 @@ class AnnotationsPane extends React.Component {
     for (let i = 0; i < this.props.annotationInProgress.points.length; i++) {
       const point = this.props.annotationInProgress.points[i];
 
-      if (i === this.props.annotationInProgress.points.length - 1) {  //Final node: click to finish annotation.
-        svgPoints.push(
-          <circle
-            id="pulsating"
-            key={svgPointPrefix + i}
-            cx={point.x} cy={point.y} r={10} fill="#00CED1"
-            className="end"
-            style={{ cursor: 'pointer' }}
-            onClick={(e) => {
-              if (this.props.onCompleteAnnotation) {
-                this.props.onCompleteAnnotation();
-              }
-              return Utility.stopEvent(e);
-            }}
-            onMouseDown={(e) => {  //Prevent triggering actions in the parent SubjectViewer.
-              return Utility.stopEvent(e);
-            }}
-            onMouseUp={(e) => {
-              return Utility.stopEvent(e);
-            }}
-          />,
-        );
-      } else {
-        svgPoints.push(
-          <circle
-            key={svgPointPrefix + i}
-            cx={point.x} cy={point.y} r={10} fill="#00CED1"
-          />,
-        );
-      }
+      svgPoints.push(
+        <circle
+          key={svgPointPrefix + i}
+          cx={point.x} cy={point.y} r={10} fill="#00CED1"
+        />,
+      );
 
       if (i > 0) {
         const prevPoint = this.props.annotationInProgress.points[i - 1];
@@ -304,7 +280,6 @@ class AnnotationsPane extends React.Component {
 
 AnnotationsPane.propTypes = {
   frame: PropTypes.number,
-  onCompleteAnnotation: PropTypes.func,
   onSelectAnnotation: PropTypes.func,
   //--------
   imageSize: PropTypes.shape({
@@ -346,7 +321,6 @@ AnnotationsPane.propTypes = {
 
 AnnotationsPane.defaultProps = {
   frame: 0,
-  onCompleteAnnotation: null,
   onSelectAnnotation: null,
   //--------
   imageSize: {

--- a/src/components/PendingAnnotation.jsx
+++ b/src/components/PendingAnnotation.jsx
@@ -41,10 +41,6 @@ class PendingAnnotation extends React.Component {
     if (this.state.pointer) {
       const prevPoint = this.props.annotationInProgress.points[i - 1];
       const beforePoint = this.props.annotationInProgress.points[i - 2];
-      if (i >= 2) {
-        const straight = this.props.angleDegree(this.state.pointer, prevPoint, beforePoint);
-        if (!straight) fill = "#c33";
-      }
       pendingPoint = (
         <circle
           key="PENDING_POINT"
@@ -73,7 +69,6 @@ class PendingAnnotation extends React.Component {
 }
 
 PendingAnnotation.propTypes = {
-  angleDegree: PropTypes.func,
   annotationInProgress: PropTypes.shape({
     text: PropTypes.string,
     points: PropTypes.arrayOf(PropTypes.shape({
@@ -86,7 +81,6 @@ PendingAnnotation.propTypes = {
 };
 
 PendingAnnotation.defaultProps = {
-  angleDegree: () => {},
   annotationInProgress: null,
   getPointerXY: () => {},
   mouseInViewer: false,

--- a/src/components/SelectedAnnotation.jsx
+++ b/src/components/SelectedAnnotation.jsx
@@ -22,7 +22,6 @@ class SelectedAnnotation extends React.Component {
     this.deleteAnnotation = this.deleteAnnotation.bind(this);
     this.insertTextModifier = this.insertTextModifier.bind(this);
     this.cancelAnnotation = this.cancelAnnotation.bind(this);
-    this.deleteAnnotation = this.deleteAnnotation.bind(this);
 
     this.state = {
       annotationText: '',

--- a/src/components/SelectedAnnotation.jsx
+++ b/src/components/SelectedAnnotation.jsx
@@ -22,7 +22,6 @@ class SelectedAnnotation extends React.Component {
     this.deleteAnnotation = this.deleteAnnotation.bind(this);
     this.insertTextModifier = this.insertTextModifier.bind(this);
     this.cancelAnnotation = this.cancelAnnotation.bind(this);
-    this.renderWordCount = this.renderWordCount.bind(this);
 
     this.state = {
       annotationText: '',
@@ -172,8 +171,6 @@ class SelectedAnnotation extends React.Component {
       width: PANE_WIDTH,
     };
 
-    const wordCountMatchesDots = this.doesWordCountMatchDots(this.state.annotationText, this.props.selectedAnnotation.points.length);
-
     return (
       <Rnd
         default={defaultPosition}
@@ -218,12 +215,8 @@ class SelectedAnnotation extends React.Component {
             this.renderAnnotationOptions()
           )}
 
-          {!this.state.showAnnotationOptions && (
-            this.renderWordCount(this.state.annotationText)
-          )}
-
           <div className="selected-annotation__buttons">
-            <button className="done-button" disabled={!wordCountMatchesDots} onClick={this.saveText}>Done</button>
+            <button className="done-button" onClick={this.saveText}>Done</button>
             <button onClick={this.cancelAnnotation}>Cancel</button>
             {(this.props.annotation.previousAnnotation) ? null :
               <button onClick={this.deleteAnnotation}>Delete</button>
@@ -264,26 +257,6 @@ class SelectedAnnotation extends React.Component {
         })}
       </div>
     )
-  }
-
-  renderWordCount(text) {
-    const expectedWords = this.props.selectedAnnotation.points.length - 1;
-    const cleaned_text = text.replace(/\s+/g, ' ').trim();
-    const number_of_words = cleaned_text ? cleaned_text.split(' ').length : 0;
-    const style = expectedWords === number_of_words ? "word-count--green" :
-      expectedWords < number_of_words ? "word-count--red" : "";
-
-    return (
-      <span className={`word-count ${style}`}>
-        {number_of_words} &#47; {expectedWords} words
-      </span>
-    )
-  }
-
-  doesWordCountMatchDots(text, dots) {
-    const cleaned_text = text.replace(/\s+/g, ' ').trim();
-    const number_of_words = cleaned_text.split(' ').length;
-    return number_of_words === dots - 1;
   }
 
   saveText() {

--- a/src/components/SelectedAnnotation.jsx
+++ b/src/components/SelectedAnnotation.jsx
@@ -22,6 +22,7 @@ class SelectedAnnotation extends React.Component {
     this.deleteAnnotation = this.deleteAnnotation.bind(this);
     this.insertTextModifier = this.insertTextModifier.bind(this);
     this.cancelAnnotation = this.cancelAnnotation.bind(this);
+    this.deleteAnnotation = this.deleteAnnotation.bind(this);
 
     this.state = {
       annotationText: '',
@@ -260,11 +261,22 @@ class SelectedAnnotation extends React.Component {
   }
 
   saveText() {
+    //There are two possibilities here: either the user is agreeing with a
+    //Previous (Aggregated) Annotation, or the user is creating/editing their
+    //own.
     if (this.props.annotation.previousAnnotation) {
       this.props.dispatch(collaborateWithAnnotation(this.props.annotation, this.state.annotationText));
       this.props.dispatch(updatePreviousAnnotation(this.props.selectedAnnotationIndex));
     } else {
-      this.props.dispatch(updateText(this.state.annotationText));
+      //If the newly updated annotation text is essentially blank, just delete this whole Annotation line.
+      const text = (this.state.annotationText && this.state.annotationText.trim)
+        ? this.state.annotationText.trim() : '';
+      if (text !== '') {
+        this.props.dispatch(updateText(text));
+      } else {
+        this.deleteAnnotation();
+      }
+      
     }
 
     if (this.context.googleLogger) {

--- a/src/containers/SubjectViewer.jsx
+++ b/src/containers/SubjectViewer.jsx
@@ -77,7 +77,6 @@ class SubjectViewer extends React.Component {
     this.getBoundingBox = this.getBoundingBox.bind(this);
     this.getPointerXY = this.getPointerXY.bind(this);
     this.getPointerXYOnImage = this.getPointerXYOnImage.bind(this);
-    this.onCompleteAnnotation = this.onCompleteAnnotation.bind(this);
     this.onSelectAnnotation = this.onSelectAnnotation.bind(this);
     this.closeAnnotation = this.closeAnnotation.bind(this);
 
@@ -143,7 +142,6 @@ class SubjectViewer extends React.Component {
               frame={this.props.frame}
               getPointerXY={this.getPointerXYOnImage}
               mouseInViewer={this.state.mouseInViewer}
-              onCompleteAnnotation={this.onCompleteAnnotation}
               onSelectAnnotation={this.onSelectAnnotation}
               previousAnnotations={this.props.previousAnnotations}
             />
@@ -308,6 +306,17 @@ class SubjectViewer extends React.Component {
     } else if (this.props.viewerState === SUBJECTVIEWER_STATE.ANNOTATING) {
       const pointerXYOnImage = this.getPointerXYOnImage(e);
       this.props.dispatch(addAnnotationPoint(pointerXYOnImage.x, pointerXYOnImage.y, this.props.frame));
+      
+      //The second added point should automatically complete the annotation.
+      //As of Dec 2017 we've moved from multi-point lines to a line consisting
+      //of a start and end point, only.
+      if (this.props.annotationInProgress && this.props.annotationInProgress.points &&
+          this.props.annotationInProgress.points.length >= 1) {
+        this.props.dispatch(completeAnnotation());
+      }
+      
+      //TODO: Check if there's an issue with addAnnotationPoint() completing AFTER completeAnnotation();
+      //I don't trust Redux.dispatch() to be synchronous given the weirdness we've seen. (@shaun 20171215)
     }
   }
 
@@ -344,13 +353,6 @@ class SubjectViewer extends React.Component {
   onMouseEnter(e) {
     this.setState({ mouseInViewer: true });
     return Utility.stopEvent(e);
-  }
-
-  /*  Triggers when the user clicks on the final node/point of an
-      annotation-in-progress.
-   */
-  onCompleteAnnotation(point) {
-    this.props.dispatch(completeAnnotation(point));
   }
 
   closeAnnotation() {

--- a/src/containers/SubjectViewer.jsx
+++ b/src/containers/SubjectViewer.jsx
@@ -140,7 +140,6 @@ class SubjectViewer extends React.Component {
               imageSize={this.props.imageSize}
               annotationInProgress={this.props.annotationInProgress}
               annotations={this.props.annotations}
-              angleDegree={this.angleDegree}
               frame={this.props.frame}
               getPointerXY={this.getPointerXYOnImage}
               mouseInViewer={this.state.mouseInViewer}
@@ -308,13 +307,6 @@ class SubjectViewer extends React.Component {
       return Utility.stopEvent(e);
     } else if (this.props.viewerState === SUBJECTVIEWER_STATE.ANNOTATING) {
       const pointerXYOnImage = this.getPointerXYOnImage(e);
-      if (this.props.annotationInProgress && this.props.annotationInProgress.points.length >= 2) {
-        const i = this.props.annotationInProgress.points.length - 1;
-        const points = this.props.annotationInProgress.points;
-
-        const straight = this.angleDegree(pointerXYOnImage, points[i], points[i - 1]);
-        if (!straight) return Utility.stopEvent(e);
-      }
       this.props.dispatch(addAnnotationPoint(pointerXYOnImage.x, pointerXYOnImage.y, this.props.frame));
     }
   }
@@ -352,15 +344,6 @@ class SubjectViewer extends React.Component {
   onMouseEnter(e) {
     this.setState({ mouseInViewer: true });
     return Utility.stopEvent(e);
-  }
-
-  angleDegree(A,B,C) {
-    const AB = Math.sqrt(Math.pow(B.x-A.x,2)+ Math.pow(B.y-A.y,2));
-    const BC = Math.sqrt(Math.pow(B.x-C.x,2)+ Math.pow(B.y-C.y,2));
-    const AC = Math.sqrt(Math.pow(C.x-A.x,2)+ Math.pow(C.y-A.y,2));
-    const radians = Math.acos((BC*BC+AB*AB-AC*AC)/(2*BC*AB));
-    const degrees = radians * 180 / Math.PI;
-    return (180 - degrees) <= MAX_ANGLE;
   }
 
   /*  Triggers when the user clicks on the final node/point of an


### PR DESCRIPTION
## PR Overview
This is a major PR that changes the way we create Annotations. We're moving from multi-point annotations (i.e. one 'dot' for each word and the end of the line of text) to "single line" annotations (i.e. one dot at the start of the line of text, one at the end)

(Becky, if you're reading this because I tagged you, the tl;dr for you is that you need to give this the Design OK after we've done the code changes. Everything else is just code jibba jabba.)

### The Plan
Generally, three things:
1. _Temporarily_ disable all Previous Annotations until the Caesar aggregation is updated.
  - `ducks/previousAnnotations` will just be hacked so that it assumes no results whatsoever.
2. Annotations should end after only two dots.
  - Also, in SelectedAnnotation, disable word count logic.
  - OPTIONAL (recommended?): revise data structure of an Annotation.
3. _Re-enable_ Previous Annotations WHEN Caesar aggregation is updated.

### Handy Checklist
- [x] When creating a Annotation, the second click/dot should trigger `completeAnnotation()`. (Done in SubjectViewer.jsx)
  - [x] Annotations In Progress should ignore angle limits.
  - [x] Annotations In Progress should no longer recognise clicking on the "last dot" to complete the Annotation.
- [x] The SelectedAnnotation component should, like, totally chill out with the word count logic. User can submit any String data... as long as it's not empty.
  - [x] Be aware of the special case where a user Cancelling out of a newly created Annotation should also Delete that new Annotation. (See below for discussion on how the Annotation data is stored.)
  - [x] NEW: When clicking DONE on a Selected Annotation with blank text, that Annotation is deleted. Remember, previously, it was impossible to submit Annotations with blank text due to the word count system, so we need to compensate for the removal of said word count. 
- [x] User should be able to submit a Classification object that makes sense to the researchers
  - [x] ...and to Coleman's aggregator
```
annotations.annotations: [
  {
    details: ["Hello", "World"],
    frame: 0,
    points: [{x:0, y:0}, {x:0, y:100}]
  }, ...
]
```
- Looking above at how the Annotation data is stored...
  - ...we can see that `.frame` is fine. `.points` can remain as-is, since we can sorta safely assume that all our annotations are lines with exactly two items (x-y coords) in the 'points' array. (Besides, changing this to `.startPoint` and `.endPoint` will take more work than necessary.)
  - ~~...however, `.details` no longer makes sense being stored as an array. 💀~~
    - ~~Recommendation: Check with Coleman how he'd like to have the data for the aggregator.~~
    - ~~By default though, I'll _replace_ `.details` with a new field called `.text`, which stores a single String.~~
  - (UPDATE) ...however, `.details` will no longer be an array of words.
    - Instead, `.details` will be an array with a _single_ item, and that item will be a full line of transcribed text.
    - e.g.: `{ details: ["I like big bugs and I cannot lie, you other entomologists can't deny
"] }`
    - See the [discussion below](https://github.com/zooniverse/anti-slavery-manuscripts/pull/198#issuecomment-352452555) for details on the 'correct' data structure.
- [ ] Tutorials and text need to be updated. (Check with Sam?)
- [ ] Once done, check with @beckyrother for final pass on new UI implementation.

### Status
WIP. This PR will be worked on by either Shaun or @wgranger 