### PR TITLE
Keep Annotation Box Within Window Bounds

### DIFF
--- a/src/components/FilmstripViewer.jsx
+++ b/src/components/FilmstripViewer.jsx
@@ -72,7 +72,7 @@ class FilmstripViewer extends React.Component {
     const MINIMUM_IMAGES_FOR_SCROLL_BUTTONS = 5;
     const renderButtons = this.props.currentSubject && this.props.currentSubject.locations.length > MINIMUM_IMAGES_FOR_SCROLL_BUTTONS;
     return (
-      <section className="filmstrip-viewer" style={{height: this.props.viewerSize.height}}>
+      <section className="filmstrip-viewer" id="filmstrip-column" style={{height: this.props.viewerSize.height}}>
         {renderButtons && (
           <button className="related-images__top" onClick={this.scroll.bind(this, false)}><i className="fa fa-chevron-up" /></button>
         )}

--- a/src/components/ProjectHeader.jsx
+++ b/src/components/ProjectHeader.jsx
@@ -37,7 +37,7 @@ class ProjectHeader extends React.Component {
       '' : 'project-header__disabled';
 
     return(
-      <div className="project-header">
+      <div id="project-header" className="project-header">
         {this.props.showTitle && (
           <h1 className="main-title">Anti-Slavery Manuscripts</h1>
         )}

--- a/src/components/ProjectHeader.jsx
+++ b/src/components/ProjectHeader.jsx
@@ -34,7 +34,7 @@ class ProjectHeader extends React.Component {
 
   render() {
     return (
-      <div className="project-header">
+      <div id="project-header" className="project-header">
         {this.props.showTitle && (
           <h1 className="main-title">Anti-Slavery Manuscripts</h1>
         )}

--- a/src/containers/ClassifierContainer.jsx
+++ b/src/containers/ClassifierContainer.jsx
@@ -108,7 +108,7 @@ class ClassifierContainer extends React.Component {
     return (
       <main className="app-content classifier-page flex-row">
         <div className="project-background"></div>
-        <section className="help-pane">
+        <section id="help-column" className="help-pane">
           <div>
             <h2>directions</h2>
             <p>

--- a/src/styles/components/classifier-page.styl
+++ b/src/styles/components/classifier-page.styl
@@ -50,7 +50,7 @@
     flex-direction: column
     font-size: (12/20)rem
     letter-spacing: (2/12)em
-    margin: 0 1rem
+    padding: 0 1rem
     width: 10rem
 
     .divider

--- a/src/styles/components/project-header.styl
+++ b/src/styles/components/project-header.styl
@@ -2,7 +2,7 @@
   display: flex
   flex-direction: row
   justify-content: space-between
-  margin: 1.5em 3.75em
+  padding: 1.5em 3.75em
 
   .main-title
     flex: 1


### PR DESCRIPTION
Fixes #79 

This PR creates a function that determines where the annotation box boundaries will lay and adjusts the box is out of bounds.

CSS styling was changed from margin to padding because `offsetWidth` and `offsetHeight` don't take margins into account.