### PR TITLE
Specify Caesar Reducer Keys

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -26,6 +26,7 @@ const baseConfig = {
     zooniverseLinks: {
       host: 'https://master.pfe-preview.zooniverse.org/',
       caesarHost: 'https://caesar-staging.zooniverse.org/graphql',
+      caesarReducerKey: 'ext-17',
       projectId: '1764',
       projectSlug: 'wgranger-test/anti-slavery-testing',
       workflowId: '3017',
@@ -39,6 +40,7 @@ const baseConfig = {
     zooniverseLinks: {
       host: 'https://www.zooniverse.org/',
       caesarHost: 'https://caesar.zooniverse.org/graphql',
+      caesarReducerKey: 'ext',
       projectId: '4973',
       projectSlug: 'bostonpubliclibrary/anti-slavery-manuscripts',
       workflowId: '5329',

--- a/src/ducks/previousAnnotations.js
+++ b/src/ducks/previousAnnotations.js
@@ -101,7 +101,7 @@ const fetchPreviousAnnotations = (subject) => {
 
     const query = `{
       workflow(id: ${workflowId}) {
-        reductions(subjectId: ${subject.id}) {
+        reductions(subjectId: ${subject.id}, reducerKey:"${config.zooniverseLinks.caesarReducerKey}") {
           data
         }
       }


### PR DESCRIPTION
## PR Overview
This PR specifies the Reducer keys when requesting aggregated data ("Previous Annotations From Other Users") from Caesar. This follows @CKrawczyk's comments from PR #198 

- If these Reducer keys are not specified, Caesar will pull different types of aggregated data (including completeness and previous incarnations of the 'Previous Annotations' data) when a request is made.
  - While strictly speaking not harmful to have the extra data, said extra data can be unnecessarily confusing when we're debugging our code and requires too much implicit understanding of how the Caesar Reducers are set up. Explicit specificity makes things much clearer in context.
- For staging, the Reducer key is `ext-17`, for production, the Reducer key is `ext`.

### Status
Ready for review, @wgranger . This looks good on staging (Subjects on our collaborative workflow show 'Previous Annotations' properly, and a check on the graphql calls shows only the requested Reducer data is returned, and not the extra data we had before) but it's harder to test on production.