### PR TITLE
Retrieve previousAnnotations When Saved Subject is Loaded

### DIFF
--- a/src/ducks/classifications.js
+++ b/src/ducks/classifications.js
@@ -220,7 +220,7 @@ const retrieveClassification = (id) => {
   return (dispatch) => {
     apiClient.type('classifications/incomplete').get({ id })
       .then(([classification]) => {
-        //TODO: Test if classification.annotations.shift() is OK; normally we don't update the classification object directly. 
+        //TODO: Test if classification.annotations.shift() is OK; normally we don't update the classification object directly.
         const subjectId = classification.links.subjects.shift();
         const annotations = classification.annotations.shift();
         dispatch(setAnnotations(annotations.value));
@@ -269,7 +269,7 @@ const saveClassificationInProgress = () => {
         localStorage.setItem(`${user.id}.classificationID`, savedClassification.id);
       }
       dispatch(toggleDialog(<SaveSuccess />, false, true));
-      
+
       //Refresh our Classification object with the newer, fresher version from
       //Panoptes. If we don't, all future .save() and .update() actions on the
       //(old) Classification object will start going wonky.

--- a/src/ducks/subject.js
+++ b/src/ducks/subject.js
@@ -262,18 +262,20 @@ const prepareForNewSubject = (dispatch, subject) => {
 const fetchSavedSubject = (id) => {
   return (dispatch) => {
     apiClient.type('subjects').get(id)
-    .then((currentSubject) => {
-      dispatch(changeFrame(0));
-      dispatch({
-        type: FETCH_SUBJECT_SUCCESS,
-        favorite: currentSubject.favorite || false,
-        currentSubject, id,
+      .then((currentSubject) => {
+        dispatch(fetchPreviousAnnotations(currentSubject));
+        dispatch(changeFrame(0));
+        dispatch({
+          type: FETCH_SUBJECT_SUCCESS,
+          favorite: currentSubject.favorite || false,
+          currentSubject,
+          id,
+        });
+      })
+      .catch((err) => {
+        console.error(err);
+        dispatch({ type: FETCH_SUBJECT_ERROR });
       });
-    })
-    .catch((err) => {
-      console.error(err);
-      dispatch({ type: FETCH_SUBJECT_ERROR });
-    })
   };
 };
 


### PR DESCRIPTION
This wound up being a simple fix. Aside from indenting some lines in `fetchSavedSubject`, the only addition I made was adding a dispatch to fetch previous annotations once the saved subject is retrieved. 

Fixes #205 
