### PR TITLE
Change when novel-transcription is Logged

### DIFF
--- a/src/containers/ClassifierContainer.jsx
+++ b/src/containers/ClassifierContainer.jsx
@@ -312,10 +312,6 @@ class ClassifierContainer extends React.Component {
   //----------------------------------------------------------------
 
   useAnnotationTool() {
-    if (this.context.googleLogger) {
-      this.context.googleLogger.logEvent({ type: 'novel-transcription' });
-    }
-
     this.props.dispatch(setViewerState(SUBJECTVIEWER_STATE.ANNOTATING));
   }
 

--- a/src/containers/SubjectViewer.jsx
+++ b/src/containers/SubjectViewer.jsx
@@ -340,6 +340,9 @@ class SubjectViewer extends React.Component {
       const pointerXYOnImage = this.getPointerXYOnImage(e);
       this.props.dispatch(addAnnotationPoint(pointerXYOnImage.x, pointerXYOnImage.y, this.props.frame));
 
+      if (this.context.googleLogger && !this.props.annotationInProgress) {
+        this.context.googleLogger.logEvent({ type: 'novel-transcription' });
+      }
       //The second added point should automatically complete the annotation.
       //As of Dec 2017 we've moved from multi-point lines to a line consisting
       //of a start and end point, only.


### PR DESCRIPTION
A slight adjustment was needed for the GoogleAnalytics logger for novel-transcription. Originally, the log was made whenever a user clicked on "annotate" on the right hang toolbar. However, now a log will be made when the _first_ dot is made in a line transcription.

Mentioned in #188 