### PR TITLE
Remove Banner

### DIFF
--- a/src/components/Banner.jsx
+++ b/src/components/Banner.jsx
@@ -2,14 +2,15 @@
 import React from 'react';
 
 const Banner = () => {
-  return (
+  return null;
+  /*return (
     <div className="beta-top-banner">
       <h2>
         We’re currently implementing some changes to the project based on
         feedback from our volunteers. Stay tuned for our next round of beta testing!
       </h2>
     </div>
-  );
+  );*/
 };
 
 export default Banner;


### PR DESCRIPTION
## PR Update
Currently, our ASM website has a special banner message that says `"We’re currently implementing some changes to the project based on feedback from our volunteers. Stay tuned for our next round of beta testing!"` if a user is *not logged in as an admin*

This doesn't make any sense as we go into Beta 2, so I'll remove it for the time being.

### Status
I'll take responsibility for merging this.

Note that I'm only commenting out the banner as I anticipate we'll need it in the future with new messages.