### PR TITLE
IE11 fix: allow Classifications to be submitted

### DIFF
--- a/src/ducks/classifications.js
+++ b/src/ducks/classifications.js
@@ -186,7 +186,9 @@ const submitClassification = () => {
       }
       //Log
       console.log('Submit classification: Success');
-      Split.classificationCreated(classification);
+      try {  //Fix: IE11 doesn't know what to do with Split.classificationCreated()
+        Split.classificationCreated(classification);
+      } catch (err) { console.error('Split.classificationCreated() error: ', err); }
 
       //Reset values in preparation for the next Subject.
       dispatch({ type: SUBMIT_CLASSIFICATION_SUCCESS });


### PR DESCRIPTION
## PR Overview
This PR fixes an issue with IE11, where - currently - if you attempt to submit a Classification (Finish -> pages fully done/not fully done -> Done), you'll receive an alert that says "ERROR: Could not submit Classification" DESPITE the fact that the Classification was submitted (as verified by console and network logs.)

The problem was that - for some mysterious reason - IE11 doesn't know how to handle `Split.classificationCreated(classification)` in `submitClassification()`, so a simply try-catch was placed around it.

### Status
Ready for review, @wgranger 