### PR TITLE
Resolve Tutorial Button Bug

### DIFF
--- a/src/ducks/project.js
+++ b/src/ducks/project.js
@@ -115,36 +115,53 @@ const fetchProject = (id = config.zooniverseLinks.projectId) => {
 
 const fetchPreferences = (user) => {
   return (dispatch, getState) => {
-    const project = getState().project.data;
-    if (project && user) {
-      user.get('project_preferences', { project_id: project.id })
-      .then(([preferences]) => {
-        dispatch({
-          type: FETCH_PREFERENCES,
-          preferences
+    const projectId = config.zooniverseLinks.projectId;
+    if (user) {
+      user.get('project_preferences', { project_id: projectId })
+        .then(([preferences]) => {
+          if (preferences) {
+            dispatch({
+              type: FETCH_PREFERENCES,
+              preferences,
+            });
+          } else {
+            apiClient.type('project_preferences').create({
+              links: { project: projectId },
+              preferences: {},
+            })
+              .save()
+              .then((newPreferences) => {
+                dispatch({
+                  type: FETCH_PREFERENCES,
+                  preferences: newPreferences,
+                });
+              })
+              .catch((err) => {
+                console.warn(err);
+              });
+          }
         });
-      });
-    } else if (project) {
+    } else {
       Promise.resolve(apiClient.type('project_preferences').create({
         id: 'GUEST_PREFERENCES_DO_NOT_SAVE',
-        links: { project: project.id },
-        preferences: {}
+        links: { project: projectId },
+        preferences: {},
       })).then((preferences) => {
         dispatch({
           type: FETCH_PREFERENCES,
-          preferences
+          preferences,
         });
       });
-    };
-  }
+    }
+  };
 };
 
 const setUserRoles = (roles) => {
   return (dispatch) => {
     dispatch({
       type: SET_USER_ROLES,
-      roles
-    })
+      roles,
+    });
   };
 };
 


### PR DESCRIPTION
Fixes #200 

This PR resolves the issue of a tutorial button not appearing for new users. Apparently, when fetching the project preference for a user, the tutorial logic was skipped if the preference was returned undefined. Turns out, an issue was already open that would implement this logic, but it had not yet been fixed.

Also fixed in this PR, it turns out the project_preferences call was made before the project resource was retrieved, so the project id is here used from the config instead.

To test this, you might need to create a new user or find a user who has not yet interacted with this project.