### PR TITLE
Allow Selecting Previous Annotations

### DIFF
--- a/src/components/AnnotationsPane.jsx
+++ b/src/components/AnnotationsPane.jsx
@@ -262,11 +262,11 @@ class AnnotationsPane extends React.Component {
             return Utility.stopEvent(e);
           }}
           onMouseDown={(e) => {  //Prevent triggering actions in the parent SubjectViewer.
-            if (previousAnnotations) return;  //If retired line, don't stop events.
+            if (annotation.consensusReached) return;  //If retired line, don't stop events.
             return Utility.stopEvent(e);
           }}
           onMouseUp={(e) => {
-            if (previousAnnotations) return;  //If retired line, don't stop events.
+            if (annotation.consensusReached) return;  //If retired line, don't stop events.
             return Utility.stopEvent(e);
           }}
         >


### PR DESCRIPTION
There was a bug introduced in #209. In this branch, a hover help box was introduced to all previous transcripts (including red lines) while also removing click functions. While this is expected for consensus (gray) lines, click actions should not have been removed for red lines.