### PR TITLE
Add Stats to Navbar and Hide Landing Page Stats

### DIFF
--- a/src/components/ProjectHeader.jsx
+++ b/src/components/ProjectHeader.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 import { connect } from 'react-redux';
 import { config } from '../config';
-import { VARIANT_TYPES } from '../ducks/splits';
 
 class ProjectHeader extends React.Component {
   constructor(props) {
@@ -11,7 +10,6 @@ class ProjectHeader extends React.Component {
 
     this.aboutClick = this.aboutClick.bind(this);
     this.talkClick = this.talkClick.bind(this);
-    this.feedbackVariant = this.feedbackVariant.bind(this);
   }
 
   aboutClick() {
@@ -24,12 +22,6 @@ class ProjectHeader extends React.Component {
     if (this.context.googleLogger) {
       this.context.googleLogger.logEvent({ type: 'header-talk-click' });
     }
-  }
-
-  feedbackVariant() {
-    return this.props.variant === VARIANT_TYPES.INDIVIDUAL
-      ? 'https://goo.gl/forms/h0V82sJQ4zEmveCH3'  //Individual-type users.
-      : 'https://goo.gl/forms/7Ur0kCxD1ZIPjNgA2';  //Collaborative-type users.
   }
 
   render() {
@@ -84,11 +76,11 @@ class ProjectHeader extends React.Component {
           </a>
           <a
             className="project-header__link"
-            href={this.feedbackVariant()}
+            href="https://www.zooniverse.org/projects/bostonpubliclibrary/anti-slavery-manuscripts/stats"
             rel="noopener noreferrer"
             target="_blank"
           >
-            Feedback
+            Stats
           </a>
         </nav>
       </div>
@@ -99,7 +91,6 @@ class ProjectHeader extends React.Component {
 ProjectHeader.defaultProps = {
   showTitle: false,
   user: null,
-  variant: VARIANT_TYPES.INDIVIDUAL,
 };
 
 ProjectHeader.propTypes = {
@@ -107,7 +98,6 @@ ProjectHeader.propTypes = {
   user: PropTypes.shape({
     admin: PropTypes.bool,
   }),
-  variant: PropTypes.string,
 };
 
 ProjectHeader.contextTypes = {
@@ -117,7 +107,6 @@ ProjectHeader.contextTypes = {
 const mapStateToProps = (state) => {
   return {
     user: state.login.user,
-    variant: state.splits.variant,
   };
 };
 

--- a/src/components/SocialSection.jsx
+++ b/src/components/SocialSection.jsx
@@ -28,7 +28,8 @@ const SocialSection = ({ project, subjectsOfNote }) =>
 
     <h2 className="main-title">Community</h2>
     <img role="presentation" className="divider" src={Divider} />
-    <div className="home-page__project-stats flex-row">
+
+    {/* <div className="home-page__project-stats flex-row">
       <div>
         <h3 className="main-title">Project Statistics</h3>
         <span className="body-copy">
@@ -66,7 +67,7 @@ const SocialSection = ({ project, subjectsOfNote }) =>
           </span>
         </div>
       </div>
-    </div>
+    </div> */}
     <div className="home-page__social-content flex-row">
       <div>
         <h3 className="main-title">Message from the researchers</h3>


### PR DESCRIPTION
This is to be merged once we are finished with beta and ready for the full launch. This PR currently hides the incorrect project stats in lieu of a stats link on the navbar until we choose which variant (collaborative or individual) we want to stick with. 

A further description is in #220