### PR TITLE
Update Banner - Second Beta is Over, Long Live ASM

### DIFF
--- a/src/components/Banner.jsx
+++ b/src/components/Banner.jsx
@@ -6,9 +6,8 @@ const Banner = ({ hideBanner }) => {
   return (
     <div className="beta-top-banner">
       <h2>
-        Thank you for participating in our second round of beta review! Please
-        sign in, and don’t forget to leave feedback using the link in the
-        top right of the page.
+        Thanks for participating in our beta review! We're making some changes
+        based on your feedback, and will be launching the full project soon!
       </h2>
       <button onClick={hideBanner}>X</button>
     </div>


### PR DESCRIPTION
## PR Overview
This is a basic text update for the Banner that tells users that the Second Beta is over, based on #223 

- All users will see this Banner; there's no special requirement (e.g. have to be logged in/admin/etc) to see it.

Note that we _won't_ lock out the Transcribe page (like with after the first Beta) since there's no harm with curious users providing extra Beta 2 Classifications, and we didn't change any Classifier functionality, like we did with Beta 1.

### Status
Minor update, I'm merging & deploying this.