### PR TITLE
[RFC] Remove Beta Mentions

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -82,7 +82,6 @@ class App extends React.Component {
       <div>
         <Header />
 
-        {/*//BETA_ONLY: Notify of beta and feedback form*/}
         {(this.props.showBanner)
           ? <Banner hideBanner={this.hideBanner} /> : null
         }

--- a/src/components/Banner.jsx
+++ b/src/components/Banner.jsx
@@ -1,10 +1,9 @@
-//BETA_ONLY
 import React from 'react';
 import PropTypes from 'prop-types';
 
 const Banner = ({ hideBanner }) => {
   return (
-    <div className="beta-top-banner">
+    <div className="top-banner">
       <h2>
         Thanks for participating in our beta review! We're making some changes
         based on your feedback, and will be launching the full project soon!

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -106,8 +106,7 @@ class Home extends React.Component {
 
           <Link to="/classify">Start Transcribing</Link>
           {/*
-          //BETA_ONLY
-          NOTE: Hide Subject Set Selection During Beta Launch.
+          NOTE: Hide Subject Set Selection During Initial Launch.
           <h3 className="transcribe">
             <Link onClick={this.setSubjectSet.bind(this, null)} to="/classify">Transcribe Random &#8608;</Link>
           </h3>

--- a/src/config.js
+++ b/src/config.js
@@ -31,8 +31,7 @@ const baseConfig = {
       projectSlug: 'wgranger-test/anti-slavery-testing',
       workflowId: '3017',
       collabWorkflowId: '3085',
-      betaSubjectSet: '4375',  //BETA_ONLY
-      gsWorkflow: '3087'
+      gsWorkflow: '3087',
     },
   },
   production: {
@@ -45,10 +44,9 @@ const baseConfig = {
       projectSlug: 'bostonpubliclibrary/anti-slavery-manuscripts',
       workflowId: '5329',
       collabWorkflowId: '5339',
-      betaSubjectSet: '16228',  //BETA_ONLY
-      gsWorkflow: '5356'
+      gsWorkflow: '5356',
     },
-  }
+  },
 };
 
 const baseSubjectSets = {

--- a/src/containers/ClassifierContainer.jsx
+++ b/src/containers/ClassifierContainer.jsx
@@ -6,7 +6,7 @@ import { Tutorial } from 'zooniverse-react-components';
 import { browserHistory } from 'react-router';
 import { config } from '../config';
 
-import oauth from 'panoptes-client/lib/oauth';  //BETA_ONLY
+import oauth from 'panoptes-client/lib/oauth';
 
 import {
   setRotation, setContrast, resetView,

--- a/src/containers/ClassifierContainer.jsx
+++ b/src/containers/ClassifierContainer.jsx
@@ -63,7 +63,7 @@ class ClassifierContainer extends React.Component {
 
     this.state = {
       popup: null,
-      showBetaSignInPrompt: true,
+      showSignInPrompt: true,
     };
   }
 
@@ -250,38 +250,35 @@ class ClassifierContainer extends React.Component {
           </Popup>
         }
 
-        { /*BETA_ONLY: Show sign in prompt to users who haven't signed in.*/
-          (!(this.props.initialised && !this.props.user && this.state.showBetaSignInPrompt)) ? null :
-            <Popup
-              className="beta-popup-sign-in-prompt"
-              onClose={() => { this.setState({ showBetaSignInPrompt: false }); }}
-            >
-              <div>
-                Thanks for participating in our beta test.
-                Before you begin transcribing, please sign in or create an account by clicking the button below:
-              </div>
-              <div>
-                <button
-                  className="green sign-in button"
-                  onClick={() => {
-                    const computeRedirectURL = (window) => {
-                      const { location } = window;
-                      return location.origin || `${location.protocol}//${location.hostname}:${location.port}`;
-                    };
-                    oauth.signIn(computeRedirectURL(window));
-                  }}
-                >
-                  Sign In
-                </button>
-                <a
-                  className="continue"
-                  onClick={() => { this.setState({ showBetaSignInPrompt: false }); }}
-                  href="#"
-                >
-                  Continue without signing in
-                </a>
-              </div>
-            </Popup>
+        {(!(this.props.initialised && !this.props.user && this.state.showSignInPrompt)) ? null :
+          <Popup
+            className="popup-sign-in-prompt"
+            onClose={() => { this.setState({ showSignInPrompt: false }); }}
+          >
+            <div>
+              Before you begin transcribing, please sign in or create an account by clicking the button below:
+            </div>
+            <div>
+              <button
+                className="green sign-in button"
+                onClick={() => {
+                  const computeRedirectURL = (window) => {
+                    const { location } = window;
+                    return location.origin || `${location.protocol}//${location.hostname}:${location.port}`;
+                  };
+                  oauth.signIn(computeRedirectURL(window));
+                }}
+              >
+                Sign In
+              </button>
+              <button
+                className="continue"
+                onClick={() => { this.setState({ showSignInPrompt: false }); }}
+              >
+                Continue without signing in
+              </button>
+            </div>
+          </Popup>
         }
 
       </main>
@@ -397,7 +394,7 @@ ClassifierContainer.propTypes = {
   goldStandardMode: PropTypes.bool,
   guide: PropTypes.object,
   icons: PropTypes.object,
-  initialised: PropTypes.bool,  //BETA_ONLY
+  initialised: PropTypes.bool,
   guideStatus: PropTypes.string,
   rotation: PropTypes.number,
   preferences: PropTypes.shape({
@@ -431,7 +428,7 @@ ClassifierContainer.defaultProps = {
   guide: null,
   guideStatus: GUIDE_STATUS.IDLE,
   icons: null,
-  initialised: false,  //BETA_ONLY
+  initialised: false,
   preferences: null,
   previousAnnotations: [],
   rotation: 0,
@@ -457,7 +454,7 @@ const mapStateToProps = (state, ownProps) => {
     guide: state.fieldGuide.guide,
     guideStatus: state.fieldGuide.status,
     icons: state.fieldGuide.icons,
-    initialised: state.login.initialised,  //BETA_ONLY
+    initialised: state.login.initialised,
     preferences: state.project.userPreferences,
     previousAnnotations: state.previousAnnotations.marks,
     rotation: state.subjectViewer.rotation,

--- a/src/ducks/login.js
+++ b/src/ducks/login.js
@@ -9,32 +9,32 @@ const SET_LOGIN_USER = 'project/user/SET_LOGIN_USER';
 
 // Reducer
 const initialState = {
- user: null,
- initialised: false,
+  user: null,
+  initialised: false,
 };
 
 const loginReducer = (state = initialState, action) => {
- switch (action.type) {
-   case SET_LOGIN_USER:
-     return Object.assign({}, state, {
-       user: action.user,  // null if logged out.
-       initialised: true,  // true once we know if user is logged in/out; false if unknown.
-     });
+  switch (action.type) {
+    case SET_LOGIN_USER:
+      return Object.assign({}, state, {
+        user: action.user,  // null if logged out.
+        initialised: true,  // true once we know if user is logged in/out; false if unknown.
+      });
 
-   default:
-     return state;
- };
+    default:
+      return state;
+  }
 };
 
 // Action Creators
 const checkLoginUser = () => {
  // First thing on app load - check if the user is logged in.
- return (dispatch) => {
-   oauth.checkCurrent()
-     .then((user) => {
-       dispatch(setLoginUser(user));
-     });
- };
+  return (dispatch) => {
+    oauth.checkCurrent()
+      .then((user) => {
+        dispatch(setLoginUser(user));
+      });
+  };
 };
 
 const loginToPanoptes = () => {
@@ -43,36 +43,36 @@ const loginToPanoptes = () => {
 };
 
 const logoutFromPanoptes = () => {
- return (dispatch) => {
-   oauth.signOut()
-     .then((user) => {
-       dispatch(setLoginUser(user));
-     });
- };
+  return (dispatch) => {
+    oauth.signOut()
+      .then((user) => {
+        dispatch(setLoginUser(user));
+      });
+  };
 };
 
 const setLoginUser = (user) => {
- return (dispatch) => {
-   if (user) {
-     apiClient.type('project_roles').get({ project_id: config.zooniverseLinks.projectId, user_id: user.id })
-     .then(([userRoles]) => {
-       if (userRoles) {
-         dispatch(setUserRoles(userRoles.roles));
-       }
-     })
-     .catch((err) => {
-       console.warn(err);
-     })
-   };
+  return (dispatch) => {
+    if (user) {
+      apiClient.type('project_roles').get({ project_id: config.zooniverseLinks.projectId, user_id: user.id })
+        .then(([userRoles]) => {
+          if (userRoles) {
+            dispatch(setUserRoles(userRoles.roles));
+          }
+        })
+        .catch((err) => {
+          console.warn(err);
+        });
+    }
 
-   dispatch({
-     type: SET_LOGIN_USER,
-     user,
-   });
+    dispatch({
+      type: SET_LOGIN_USER,
+      user,
+    });
 
-   dispatch(fetchSplit(user));
-   dispatch(fetchPreferences(user));
- };
+    dispatch(fetchSplit(user));
+    dispatch(fetchPreferences(user));
+  };
 };
 
 // Helper functions
@@ -86,8 +86,8 @@ const computeRedirectURL = (window) => {
 export default loginReducer;
 
 export {
- checkLoginUser,
- loginToPanoptes,
- logoutFromPanoptes,
- setLoginUser,
+  checkLoginUser,
+  loginToPanoptes,
+  logoutFromPanoptes,
+  setLoginUser,
 };

--- a/src/ducks/subject.js
+++ b/src/ducks/subject.js
@@ -186,7 +186,7 @@ const fetchSubject = (initialFetch = false) => {
       type: FETCH_SUBJECT,
     });
 
-    // BETA_ONLY
+    // INITIAL_LAUNCH_ONLY
     //----------------
     let subjectQuery = { workflow_id };
 
@@ -200,7 +200,7 @@ const fetchSubject = (initialFetch = false) => {
     }
     subjectQuery.subject_set_id = randomSubjectSet;
 
-    // Removed for //BETA_ONLY
+    // Removed for //INITIAL_LAUNCH_ONLY
     // if (getState().subject.subjectSet) {
     //   subjectQuery.subject_set_id = getState().subject.subjectSet;
     // }

--- a/src/styles/components/top-banner.styl
+++ b/src/styles/components/top-banner.styl
@@ -1,4 +1,4 @@
-.beta-top-banner  //BETA_ONLY
+.top-banner
   background-color: $teal
   color: white
   display: flex
@@ -19,7 +19,7 @@
   h2
     margin: 0
 
-.popup.beta-popup-sign-in-prompt  //BETA_ONLY
+.popup.popup-sign-in-prompt
   z-index: 100  //Place the prompt above the ZRC Tutorial.
 
   .popup-content


### PR DESCRIPTION
This branch removes all mentions of beta in both the code and UI. The PR is currently RFC because there are a few items to discuss.

- Although I understand why `login.initialised` is present in the ducks, I'm not sure it is changing much in the frontend logic. 
- Although the top banner was initially marked `BETA_ONLY`, I think it makes sense to keep it in if we want to make an announcement in the future.
- It's possible we will need subject set selection once more subject sets are introduced. For now, the comments were changed to `INITIAL_LAUNCH_ONLY`