### PR TITLE
Change Log Type for Previous Annotation

### DIFF
--- a/src/components/SelectedAnnotation.jsx
+++ b/src/components/SelectedAnnotation.jsx
@@ -311,7 +311,7 @@ class SelectedAnnotation extends React.Component {
     }
 
     if (this.context.googleLogger && this.state.previousTranscriptionSelection) {
-      this.context.googleLogger.logEvent({ type: 'select-previous-annotation' });
+      this.context.googleLogger.logEvent({ type: 'previous-annotation-agreement' });
     }
 
     this.props.onClose();


### PR DESCRIPTION
A small line change was made to better reflect what is going on with this event type when logged to Google Analytics.