### PR TITLE
Allow IE to Log Seven-ten

### DIFF
--- a/src/ducks/previousAnnotations.js
+++ b/src/ducks/previousAnnotations.js
@@ -123,7 +123,6 @@ const fetchPreviousAnnotations = (subject) => {
       });
     })
     .catch((err) => {
-      console.log(err);
       dispatch({ type: FETCH_ANNOTATIONS_ERROR });
     });
   };

--- a/src/ducks/previousAnnotations.js
+++ b/src/ducks/previousAnnotations.js
@@ -123,6 +123,7 @@ const fetchPreviousAnnotations = (subject) => {
       });
     })
     .catch((err) => {
+      console.log(err);
       dispatch({ type: FETCH_ANNOTATIONS_ERROR });
     });
   };

--- a/src/index.tpl.html
+++ b/src/index.tpl.html
@@ -4,7 +4,6 @@
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <title>Anti-Slavery Manuscripts</title>
-    <script src="https://ft-polyfill-service.herokuapp.com/v2/polyfill.min.js?features=default,Array.prototype.includes,Array.prototype.keys"></script>
 
     <!-- Google Analytics -->
     <script>
@@ -25,5 +24,7 @@
   <body>
     <div id="root"></div>
     <%= htmlWebpackPlugin.options.gtm %>
+
+    <script src="https://ft-polyfill-service.herokuapp.com/v2/polyfill.min.js?features=default,es6,Array.prototype.includes,Array.prototype.keys"></script>
   </body>
 </html>


### PR DESCRIPTION
My initial testing of this branch, after the addition of `es6` to the polyfill, appears to solve the issue of logging `Split.classificationCreated()`, but my console access w/ my IE VM is a little spotty, so it's worth a further review before any merge.

Fixes #214