### PR TITLE
Remove banner message for full launch

### DIFF
--- a/src/components/Banner.jsx
+++ b/src/components/Banner.jsx
@@ -2,6 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Banner = ({ hideBanner }) => {
+  //If no messages, just return null.
+  return null;
+  
+  /*
   return (
     <div className="top-banner">
       <h2>
@@ -11,6 +15,7 @@ const Banner = ({ hideBanner }) => {
       <button onClick={hideBanner}>X</button>
     </div>
   );
+  */
 };
 
 Banner.propTypes = {


### PR DESCRIPTION
## PR Status
The teal banner at the top of the website that says _"Thanks for participating in our beta review! We're making some changes based on your feedback, and will be launching the full project soon!"_ which doesn't make any more sense now that we're heading into a full launch.

This PR removes it.

### Status
I'm going to merge & deploy this.