### PR TITLE
More Error/Status logging and remove shift() from retrieveClassification()

### DIFF
--- a/src/ducks/classifications.js
+++ b/src/ducks/classifications.js
@@ -236,10 +236,11 @@ const retrieveClassification = (id) => {
     
     apiClient.type('classifications/incomplete').get({ id })
       .then(([classification]) => {
-      
-        //TODO: Test if classification.annotations.shift() is OK; normally we don't update the classification object directly.
-        const subjectId = classification.links.subjects.shift();
-        const annotations = classification.annotations.shift();
+        const subjectId = (classification.links && classification.links.subjects && classification.links.subjects.length > 0)
+          ? classification.links.subjects[0] : null;
+        const annotations = (classification.annotations)
+          ? classification.annotations[0] : { value: [] };
+        if (subjectId === null) { throw 'Subject ID could not be determined.'; }
       
         console.info('ducks/classifications.js submitClassification() success');
         dispatch(setAnnotations(annotations.value));

--- a/src/ducks/classifications.js
+++ b/src/ducks/classifications.js
@@ -137,9 +137,9 @@ const submitClassification = () => {
     const user = getState().login.user;
 
     if (!classification) {
-      console.error('ducks/classifications.js submitClassification() error (no classification): ', err);
+      console.error('ducks/classifications.js submitClassification() error: no classification', '');
       Rollbar && Rollbar.error &&
-      Rollbar.error('ducks/classifications.js submitClassification() error (no classification): ', err);  //TODO: better presentation
+      Rollbar.error('ducks/classifications.js submitClassification() error: no classification', '');  //TODO: better presentation
       alert('ERROR: Could not submit Classification.');
       return;
     }
@@ -237,6 +237,9 @@ const retrieveClassification = (id) => {
     apiClient.type('classifications/incomplete').get({ id })
       .then(([classification]) => {
         //TODO: Test if classification.annotations.shift() is OK; normally we don't update the classification object directly.
+      
+        console.log('x'.repeat(80), '\n', classification.links.subjects, '\n', classification.annotations);  //TEST
+      
         const subjectId = classification.links.subjects.shift();
         const annotations = classification.annotations.shift();
         dispatch(setAnnotations(annotations.value));

--- a/src/ducks/classifications.js
+++ b/src/ducks/classifications.js
@@ -43,6 +43,7 @@ const classificationReducer = (state = initialState, action) => {
 
     case CREATE_CLASSIFICATION_ERROR:
       return Object.assign({}, state, {
+        classification: null,
         status: CLASSIFICATION_STATUS.ERROR
       });
 
@@ -103,6 +104,12 @@ const createClassification = () => {
         workflow: getState().workflow.id,
         subjects: [getState().subject.id]
       }
+    })
+    .catch((err) => {
+      console.error('ducks/classifications.js createClassification() error: ', err);
+      Rollbar && Rollbar.error &&
+      Rollbar.error('ducks/classifications.js createClassification() error: ', err);
+      alert('ERROR: Could not initialise system. Please reload the page.');  //TODO: better presentation
     });
     classification._workflow = getState().workflow.data;
     classification._subjects = [getState().subject.currentSubject];
@@ -129,8 +136,13 @@ const submitClassification = () => {
     const updatedAnnotations = [];  //Always start empty (don't pull anything from classification.annotation) the build the array based on the answers we have.
     const user = getState().login.user;
 
-    //TODO: Better error handling
-    if (!classification) { alert('ERROR: Could not submit Classification.'); return; }
+    if (!classification) {
+      console.error('ducks/classifications.js submitClassification() error (no classification): ', err);
+      Rollbar && Rollbar.error &&
+      Rollbar.error('ducks/classifications.js submitClassification() error (no classification): ', err);  //TODO: better presentation
+      alert('ERROR: Could not submit Classification.');
+      return;
+    }
     //----------------
 
     //Record the first task
@@ -198,11 +210,10 @@ const submitClassification = () => {
 
       //Unsuccessful save
       .catch((err) => {
-        //TODO: Proper error handling
         console.error('ducks/classifications.js submitClassification() error: ', err);
         Rollbar && Rollbar.error &&
         Rollbar.error('ducks/classifications.js submitClassification() error: ', err);
-        alert('ERROR: Could not submit Classification');
+        alert('ERROR: Could not submit Classification');  //TODO: better messaging
         dispatch({ type: SUBMIT_CLASSIFICATION_ERROR });
       });
     //----------------
@@ -282,6 +293,7 @@ const saveClassificationInProgress = () => {
       //Panoptes. If we don't, all future .save() and .update() actions on the
       //(old) Classification object will start going wonky.
       dispatch({ type: UPDATE_CLASSIFICATION, classification: savedClassification });
+      console.log('ducks/classifications.js saveClassificationInProgress(): success');
     })
     .catch((err) => {
       console.error('ducks/classifications.js saveClassificationInProgress() error: ', err);

--- a/src/ducks/login.js
+++ b/src/ducks/login.js
@@ -53,6 +53,7 @@ const logoutFromPanoptes = () => {
 
 const setLoginUser = (user) => {
   return (dispatch) => {
+    console.info('ducks/login.js setLoginUser(): user ', user, ', user.id ', (user && user.id));
     if (user) {
       apiClient.type('project_roles').get({ project_id: config.zooniverseLinks.projectId, user_id: user.id })
         .then(([userRoles]) => {

--- a/src/ducks/subject.js
+++ b/src/ducks/subject.js
@@ -163,6 +163,7 @@ const setImageMetadata = (frameId, metadata) => {
 }
 
 const selectSubjectSet = (id) => {
+  console.info('ducks/subject.js selectSubjectSet(): id ', id);
   return (dispatch) => {
     dispatch({
       type: SET_SUBJECT_SET,
@@ -178,8 +179,10 @@ const selectSubjectSet = (id) => {
  */
 const fetchSubject = (initialFetch = false) => {
   return (dispatch, getState) => {
+    console.info('ducks/subject.js fetchSubject() init');
     if (initialFetch && getState().subject.status !== SUBJECT_STATUS.IDLE) return;
     const workflow_id = getState().workflow.id;
+    console.info('ducks/subject.js fetchSubject(): workflow_id ', workflow_id);
 
     let savedClassificationPrompt = false;
     const user = getState().login.user;
@@ -212,6 +215,8 @@ const fetchSubject = (initialFetch = false) => {
     //   subjectQuery.subject_set_id = getState().subject.subjectSet;
     // }
     //----------------
+    
+    console.info('ducks/subject.js fetchSubject(): subject_set_id ', subjectQuery.subject_set_id);
 
     const gsMode = getState().workflow.goldStandardMode;
     if (gsMode) {
@@ -228,7 +233,8 @@ const fetchSubject = (initialFetch = false) => {
             type: FETCH_SUBJECT_SUCCESS,
             favorite: currentSubject.favorite || false,
           });
-
+        
+          console.info('ducks/subject.js fetchSubject() fetch subject success: subject id ', currentSubject.id);
           prepareForNewSubject(dispatch, currentSubject);
         })
         .catch((err) => {


### PR DESCRIPTION
## PR Overview
Background: ASM users are encountering issues submitting Classifications and we don't know why. One clue is that a number of said users tried using the Save Progress feature, and we detected that there may be an issue with `retrieveClassification()` function

This PR:
- Adds more console logs (for both successes and failures) which will be picked up by Rollbar, which should help future debugging.
- Fixes `retrieveClassification()` so that it no longer uses the `Array.shift()` method, because that actually changes the value of the `classification` object... and the Panoptes `classification` object should _only_ have its values changed via the `classification.update()` method.
  - Note: As far as I can determine, the values shift()ed in the `classification()` _don't need to be changed_ at retrieveClassification().
  - i.e. `retrievedClassification.links.subjects` should remain as is (shift() would turn it into an empty array) and `retrievedClassification.annotations` get overwritten later anyway with proper `.update()` calls.

### Status
@wgranger This is ready for review, but may require some pretty thorough testing.