### PR TITLE
Removed classificationObject from catch()

### DIFF
--- a/src/ducks/classifications.js
+++ b/src/ducks/classifications.js
@@ -174,7 +174,6 @@ const saveAllQueuedClassifications = (dispatch, user = null) => {
         //Ah, crap.
         itemsFailed++;
         
-        console.error('ducks/classifications.js saveAllQueuedClassifications() failure: item ', classificationObject.id);
         console.error('ducks/classifications.js saveAllQueuedClassifications() error: ', err);
         Rollbar && Rollbar.error &&
         Rollbar.error('ducks/classifications.js saveAllQueuedClassifications() error: ', err);


### PR DESCRIPTION
## PR Overview
DERP. The `catch()` clause doesn't have `classificationObject`, so it doesn't make sense for `console.error()` to report it.

### Status
@wgranger please take a look at this.