### PR TITLE
Failed Classifications with 422 errors shouldn't pop an alert

### DIFF
--- a/src/ducks/classifications.js
+++ b/src/ducks/classifications.js
@@ -172,8 +172,6 @@ const saveAllQueuedClassifications = (dispatch, user = null) => {
       //FAILURE
       .catch((err) => {
         //Ah, crap.
-        itemsFailed++;
-        
         console.error('ducks/classifications.js saveAllQueuedClassifications() error: ', err);
         Rollbar && Rollbar.error &&
         Rollbar.error('ducks/classifications.js saveAllQueuedClassifications() error: ', err);
@@ -184,6 +182,7 @@ const saveAllQueuedClassifications = (dispatch, user = null) => {
             break;
 
           default:  //Otherwise, the failed Classification should be re-queued for the next time attempt.
+            itemsFailed++;  //Let the user know that the Classification will be re-queued.
             newQueue.push(classificationData);
         }
       })
@@ -193,6 +192,8 @@ const saveAllQueuedClassifications = (dispatch, user = null) => {
 
         //Have all items been processed?
         if (itemsProcessed === itemsToProcess) {
+          console.info('ducks/classifications.js saveAllQueuedClassifications() finished: ${itemsProcessed} items processed, ${itemsFailed} failures');
+          
           //Did anything fail?
           if (itemsFailed > 0) {
             //TODO: better presentation


### PR DESCRIPTION
## PR Overview
This is a messaging issue. When a Classification is submitted and a 422 is received in response, it means the Classification is invalid (something must have gone horribly wrong with the code) and therefore _cannot_ be re-queued.

This PR ensures that the "we'll try again later" message _only_ appears when a failed Classification is re-queued. (i.e. anything but a 422)

### Status
Ready for review, @wgranger 