### PR TITLE
Change Content and Minor Errors

### DIFF
--- a/src/components/AboutTheCollection.jsx
+++ b/src/components/AboutTheCollection.jsx
@@ -57,7 +57,7 @@ class AboutTheCollection extends React.Component {
               </div>
               <div>
                 While the abolitionists were united in their fight against the enslavement
-                of blacks, they were not always united when it came to the question
+                of Black people, they were not always united when it came to the question
                 of whether or not women should participate in the movement.
               </div>
               <div>

--- a/src/components/AlreadySeen.jsx
+++ b/src/components/AlreadySeen.jsx
@@ -6,7 +6,7 @@ const AlreadySeen = () => {
       <span>
         You have already seen this manuscript and submitted a classification.
         Don&apos;t worry, we are constantly adding new subjects to the site.
-        You can still annotate and view manuscripts you have already seen before.
+        You can still transcribe and view manuscripts you have already seen before.
       </span>
     </div>
   );

--- a/src/components/AnnotationReminder.jsx
+++ b/src/components/AnnotationReminder.jsx
@@ -34,7 +34,7 @@ class AnnotationReminder extends React.Component {
         </span>
 
         <span>
-          Please annotate and transcribe entire lines at a time. Words split
+          Please transcibe and transcribe entire lines at a time. Words split
           between two lines should be typed out in their entirety on the first line.
           If you&apos;re unsure of anything, please revisit the project tutorial.
         </span>

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -62,13 +62,13 @@ class Home extends React.Component {
           const newestSubjects = uniqueSubjects.slice(0, 4);
           apiClient.type('subjects').get(newestSubjects)
             .then((subjectsOfNote) => {
-              this.setState({ subjectsOfNote })
+              this.setState({ subjectsOfNote });
             });
         }
       })
       .catch((err) => {
         console.error('Home.fetchRecentSubjects() error: ', err);
-      })
+      });
   }
 
   toggleGoldStandard() {
@@ -81,7 +81,7 @@ class Home extends React.Component {
         <div key={`Subject_Set_${i}`}>
           <Link onClick={this.setSubjectSet.bind(this, set.id)} to="/classify">{set.title}</Link>
         </div>
-      )
+      );
     });
   }
 
@@ -101,7 +101,8 @@ class Home extends React.Component {
           <img role="presentation" className="divider" src={Divider} />
           <div className="home-page__body-text">
             <b className="body-copy-first-word">Welcome.</b>{' '}
-            {this.props.project && this.props.project.description}
+            {this.props.project && this.props.project.description}<br />
+            <span><b>Note:</b> This project is not currently supported on mobile and tablet devices.</span>
           </div>
 
           <Link to="/classify">Start Transcribing</Link>

--- a/src/components/KeyboardShortcuts.jsx
+++ b/src/components/KeyboardShortcuts.jsx
@@ -14,7 +14,7 @@ const KeyboardShortcuts = () => {
         </tr>
         <tr>
           <td>a</td>
-          <td>Toggle Navigate and Annotate</td>
+          <td>Toggle Navigate and Transcribe</td>
         </tr>
         <tr>
           <th>When Transcribing</th>

--- a/src/components/KeyboardShortcuts.jsx
+++ b/src/components/KeyboardShortcuts.jsx
@@ -5,28 +5,30 @@ const KeyboardShortcuts = () => {
     <div className="keyboard-shortcuts">
       <h2>Keyboard Shortcuts</h2>
       <table>
-        <tr>
-          <th>When Annotating</th>
-        </tr>
-        <tr>
-          <td>m</td>
-          <td>Toggle Previous Marks</td>
-        </tr>
-        <tr>
-          <td>a</td>
-          <td>Toggle Navigate and Transcribe</td>
-        </tr>
-        <tr>
-          <th>When Transcribing</th>
-        </tr>
-        <tr>
-          <td>ctrl + enter</td>
-          <td>Submit Classifications</td>
-        </tr>
-        <tr>
-          <td>esc</td>
-          <td>Close and Cancel Transcription Box</td>
-        </tr>
+        <tbody>
+          <tr>
+            <th>When Annotating</th>
+          </tr>
+          <tr>
+            <td>m</td>
+            <td>Toggle Previous Marks</td>
+          </tr>
+          <tr>
+            <td>a</td>
+            <td>Toggle Navigate and Transcribe</td>
+          </tr>
+          <tr>
+            <th>When Transcribing</th>
+          </tr>
+          <tr>
+            <td>ctrl + enter</td>
+            <td>Submit Classifications</td>
+          </tr>
+          <tr>
+            <td>esc</td>
+            <td>Close and Cancel Transcription Box</td>
+          </tr>
+        </tbody>
       </table>
     </div>
 

--- a/src/components/SaveClip.jsx
+++ b/src/components/SaveClip.jsx
@@ -14,24 +14,6 @@ class SaveClip extends React.Component {
     this.saveClip = this.saveClip.bind(this);
   }
 
-  componentDidMount() {
-    this.inputText.addEventListener('mousedown', () => {
-      this.dialog.className = DISABLE_DRAG;
-    });
-    this.inputText.addEventListener('mouseup', () => {
-      this.dialog.className = ENABLE_DRAG;
-    });
-  }
-
-  componentWillUnmount() {
-    this.inputText.removeEventListener('mousedown', () => {
-      this.dialog.className = DISABLE_DRAG;
-    });
-    this.inputText.removeEventListener('mouseup', () => {
-      this.dialog.className = ENABLE_DRAG;
-    });
-  }
-
   cropUrl() {
     if (!this.props.points) return null;
     const { width, height, x, y } = this.props.points;
@@ -76,7 +58,13 @@ class SaveClip extends React.Component {
         <div className="save-snippet__image">
           <img role="presentation" src={this.cropUrl()} />
         </div>
-        <input type="text" ref={(c) => { this.inputText = c; }} placeholder="Snippet Name" />
+        <input
+          type="text"
+          ref={(c) => { this.inputText = c; }}
+          onMouseDown={() => { this.dialog.className = DISABLE_DRAG; }}
+          onMouseUp={() => { this.dialog.className = ENABLE_DRAG; }}
+          placeholder="Snippet Name"
+        />
 
         <div className="save-snippet__buttons">
           <button onClick={this.props.onClose}>Cancel</button>

--- a/src/components/SelectedAnnotation.jsx
+++ b/src/components/SelectedAnnotation.jsx
@@ -52,12 +52,9 @@ class SelectedAnnotation extends React.Component {
 
   componentWillUnmount() {
     document.removeEventListener('keyup', this.handleKeyUp);
-    this.inputText.removeEventListener('mousedown', () => {
-      this.dialog.className = DISABLE_DRAG;
-    });
-    this.inputText.removeEventListener('mouseup', () => {
-      this.dialog.className = ENABLE_DRAG;
-    });
+    if (this.inputText) {
+      this.removeEventListeners();
+    }
   }
 
   toggleShowAnnotations() {
@@ -323,11 +320,22 @@ class SelectedAnnotation extends React.Component {
     this.props.onClose();  //Note that deleteSelectedAnnotation() also runs unselectAnnotation(), but this needs to be called anyway to inform the parent component.
   }
 
+  removeEventListeners() {
+    this.inputText.removeEventListener('mouseup', () => {
+      this.dialog.className = ENABLE_DRAG;
+    });
+    this.inputText.removeEventListener('mousedown', () => {
+      this.dialog.className = DISABLE_DRAG;
+    });
+  }
+
   handleKeyUp(e) {
     if (Utility.getKeyCode(e) === KEY_CODES.ESCAPE) {
+      this.removeEventListeners();
       this.cancelAnnotation();
     }
     if (Utility.getKeyCode(e) === KEY_CODES.ENTER && e.ctrlKey) {
+      this.removeEventListeners();
       this.saveText();
     }
   }

--- a/src/components/SelectedAnnotation.jsx
+++ b/src/components/SelectedAnnotation.jsx
@@ -10,8 +10,8 @@ const PANE_WIDTH = 800;
 const PANE_HEIGHT = 350;
 const BUFFER = 10;
 
-const ENABLE_DRAG = "handle selected-annotation";
-const DISABLE_DRAG = "selected-annotation";
+const ENABLE_DRAG = 'handle selected-annotation';
+const DISABLE_DRAG = 'selected-annotation';
 
 class SelectedAnnotation extends React.Component {
   constructor(props) {
@@ -41,27 +41,18 @@ class SelectedAnnotation extends React.Component {
     }
     document.addEventListener('keyup', this.handleKeyUp);
     this.setState({ annotationText: text });
-    this.inputText.addEventListener('mousedown', () => {
-      this.dialog.className = DISABLE_DRAG;
-    });
-    this.inputText.addEventListener('mouseup', () => {
-      this.dialog.className = ENABLE_DRAG;
-    });
     this.inputText.focus();
   }
 
   componentWillUnmount() {
     document.removeEventListener('keyup', this.handleKeyUp);
-    if (this.inputText) {
-      this.removeEventListeners();
-    }
   }
 
   toggleShowAnnotations() {
     if (this.context.googleLogger) {
       this.context.googleLogger.logEvent({
         type: 'click-dropdown',
-        timestamp: new Date().toISOString()
+        timestamp: new Date().toISOString(),
       });
     }
 
@@ -186,7 +177,7 @@ class SelectedAnnotation extends React.Component {
     inputY = inputY * this.props.scaling + (this.props.translationY * this.props.scaling);
     inputY = inputY + this.props.viewerSize.height / 2;
 
-    const inputClass = this.props.annotation.previousAnnotation ? "selected-annotation__previous" : "selected-annotation__user";
+    const inputClass = this.props.annotation.previousAnnotation ? 'selected-annotation__previous' : 'selected-annotation__user';
 
     const boundPos = this.checkPaneBounds(inputX, inputY);
 
@@ -226,7 +217,15 @@ class SelectedAnnotation extends React.Component {
           </div>
 
           <p>
-            <input className={inputClass} type="text" ref={(c) => { this.inputText = c; }} onChange={this.onTextUpdate} value={this.state.annotationText} />
+            <input
+              className={inputClass}
+              type="text"
+              ref={(c) => { this.inputText = c; }}
+              onChange={this.onTextUpdate}
+              onMouseDown={() => { this.dialog.className = DISABLE_DRAG; }}
+              onMouseUp={() => { this.dialog.className = ENABLE_DRAG; }}
+              value={this.state.annotationText}
+            />
 
             {this.props.annotation.previousAnnotation && (
               <button onClick={this.toggleShowAnnotations}>
@@ -262,7 +261,7 @@ class SelectedAnnotation extends React.Component {
     if (initialAnnotationText.trim().length === 0) {
       this.deleteAnnotation();  //Cancel this action and delete this newly created Annotation.
     } else {
-      if (this.props.onClose) { this.props.onClose() };  //Cancel this action and make no updates to the existing (and valid) Annotation.
+      if (this.props.onClose) { this.props.onClose(); }  //Cancel this action and make no updates to the existing (and valid) Annotation.
     }
 
     if (this.context.googleLogger) {
@@ -300,7 +299,6 @@ class SelectedAnnotation extends React.Component {
       } else {
         this.deleteAnnotation();
       }
-
     }
 
     if (this.context.googleLogger) {
@@ -320,22 +318,11 @@ class SelectedAnnotation extends React.Component {
     this.props.onClose();  //Note that deleteSelectedAnnotation() also runs unselectAnnotation(), but this needs to be called anyway to inform the parent component.
   }
 
-  removeEventListeners() {
-    this.inputText.removeEventListener('mouseup', () => {
-      this.dialog.className = ENABLE_DRAG;
-    });
-    this.inputText.removeEventListener('mousedown', () => {
-      this.dialog.className = DISABLE_DRAG;
-    });
-  }
-
   handleKeyUp(e) {
     if (Utility.getKeyCode(e) === KEY_CODES.ESCAPE) {
-      this.removeEventListeners();
       this.cancelAnnotation();
     }
     if (Utility.getKeyCode(e) === KEY_CODES.ENTER && e.ctrlKey) {
-      this.removeEventListeners();
       this.saveText();
     }
   }
@@ -355,6 +342,7 @@ class SelectedAnnotation extends React.Component {
 }
 
 SelectedAnnotation.defaultProps = {
+  annotation: {},
   annotationPanePosition: {
     x: 0,
     y: 0,
@@ -371,6 +359,9 @@ SelectedAnnotation.defaultProps = {
 };
 
 SelectedAnnotation.propTypes = {
+  annotation: PropTypes.shape({
+    details: React.PropTypes.array,
+  }),
   annotationPanePosition: PropTypes.shape({
     x: PropTypes.number,
     y: PropTypes.number,

--- a/src/components/ShowMetadata.jsx
+++ b/src/components/ShowMetadata.jsx
@@ -7,22 +7,24 @@ const ShowMetadata = ({ metadata }) => {
     <div className="handle show-metadata">
       <img role="presentation" className="divider" src={Divider} />
       <table width="100%">
-        {Object.keys(metadata).map((key, i) => {
-          const isHidden = /^\s*#|(\/\/)|!/g.test(key);
-          if (metadata[key] && !isHidden) {
-            const isUrl = metadata[key].substring(0, 4) === 'http';
-            let info = metadata[key];
-            if (isUrl) {
-              info = <a target="_blank" rel="noopener noreferrer" href={metadata[key]}>{metadata[key]}</a>;
+        <tbody>
+          {Object.keys(metadata).map((key, i) => {
+            const isHidden = /^\s*#|(\/\/)|!/g.test(key);
+            if (metadata[key] && !isHidden) {
+              const isUrl = metadata[key].substring(0, 4) === 'http';
+              let info = metadata[key];
+              if (isUrl) {
+                info = <a target="_blank" rel="noopener noreferrer" href={metadata[key]}>{metadata[key]}</a>;
+              }
+              return (
+                <tr key={i}>
+                  <td><b>{key}</b></td>
+                  <td>{info}</td>
+                </tr>
+              );
             }
-            return (
-              <tr key={i}>
-                <td><b>{key}</b></td>
-                <td>{info}</td>
-              </tr>
-            );
-          }
-        })}
+          })}
+        </tbody>
       </table>
     </div>
   );

--- a/src/components/SocialSection.jsx
+++ b/src/components/SocialSection.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Divider from '../images/img_divider.png';
+import { config } from '../config';
 import { getSubjectLocation, getThumbnailSource } from '../lib/get-subject-location';
 
 const SocialSection = ({ project, subjectsOfNote }) =>
@@ -14,12 +15,15 @@ const SocialSection = ({ project, subjectsOfNote }) =>
 
           {subjectsOfNote.map((subject, i) => {
             const location = getSubjectLocation(subject);
+            const url = `${config.zooniverseLinks.host}projects/${project.slug}/talk/subjects/${subject.id}`;
             const thumbnail = (location && location.src) ? getThumbnailSource(location.src) : undefined;
             return (
               <div key={i}>
-                <img src={thumbnail} />
+                <a href={url} rel="noopener noreferrer" target="_blank">
+                  <img role="presentation" src={thumbnail} />
+                </a>
               </div>
-            )
+            );
           })}
 
         </div>
@@ -84,8 +88,8 @@ const SocialSection = ({ project, subjectsOfNote }) =>
         </div>
         <div className="social-bar">
           <div>
-            <a href="https://twitter.com/BPLBoston" target="_blank">
-              <i className="fa fa-twitter fa-2x"/>
+            <a href="https://twitter.com/BPLBoston" rel="noopener noreferrer" target="_blank">
+              <i className="fa fa-twitter fa-2x" />
               <div>
                 <span>Twitter</span>
                 <span>@BPLBoston</span>
@@ -93,8 +97,8 @@ const SocialSection = ({ project, subjectsOfNote }) =>
             </a>
           </div>
           <div>
-            <a href="https://www.facebook.com/bostonpubliclibrary/" target="_blank">
-              <i className="fa fa-facebook fa-2x"/>
+            <a href="https://www.facebook.com/bostonpubliclibrary/" rel="noopener noreferrer" target="_blank">
+              <i className="fa fa-facebook fa-2x" />
               <div>
                 <span>Facebook</span>
                 <span>@bostonpubliclibrary</span>
@@ -102,8 +106,8 @@ const SocialSection = ({ project, subjectsOfNote }) =>
             </a>
           </div>
           <div>
-            <a href="https://www.instagram.com/bplboston" target="_blank">
-              <i className="fa fa-instagram fa-2x"/>
+            <a href="https://www.instagram.com/bplboston" rel="noopener noreferrer" target="_blank">
+              <i className="fa fa-instagram fa-2x" />
               <div>
                 <span>Instagram</span>
                 <span>@bplboston</span>
@@ -116,19 +120,17 @@ const SocialSection = ({ project, subjectsOfNote }) =>
   </div>;
 
 SocialSection.defaultProps = {
-  percentComplete: 0,
   project: {
     classifiers_count: 0,
     completeness: 0,
     researcher_quote: '',
     retired_subjects_count: 0,
-    subjects_count: 0
+    subjects_count: 0,
   },
   subjectsOfNote: [],
 };
 
 SocialSection.propTypes = {
-  percentComplete: PropTypes.number,
   project: PropTypes.shape({
     classifiers_count: PropTypes.number,
     completeness: PropTypes.number,

--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -4,17 +4,17 @@ import timelineEvents from '../lib/timeline-events';
 import Text from './Text';
 
 const collectionGroups = [{
-  years: "1820-1840",
-  width: "50"
+  years: '1820-1840',
+  width: '50',
 }, {
-  years: "1840-1860",
-  width: "100"
+  years: '1840-1860',
+  width: '100',
 }, {
-  years: "1860-1880",
-  width: "70"
+  years: '1860-1880',
+  width: '70',
 }, {
-  years: "1880-1900",
-  width: "10"
+  years: '1880-1900',
+  width: '10',
 }];
 
 class Timeline extends React.Component {
@@ -26,12 +26,11 @@ class Timeline extends React.Component {
     this.renderEvent = this.renderEvent.bind(this);
     this.renderText = this.renderText.bind(this);
     this.renderGroups = this.renderGroups.bind(this);
-    this.handleOnBlur = this.handleOnBlur.bind(this);
 
     this.state = {
       activeEvent: null,
-      timelineWidth: 100
-    }
+      timelineWidth: 100,
+    };
   }
 
   componentDidMount() {
@@ -49,11 +48,11 @@ class Timeline extends React.Component {
     let color = 'black';
 
     if (date.includes('-')) {
-      const dates = date.split(/\s*-\s*/)
+      const dates = date.split(/\s*-\s*/);
       startDate = dates[0];
       const yearDifference = dates[1] - dates[0];
       yearWidth = yearDifference / TIMELINE_LENGTH * this.state.timelineWidth;
-      if (yearDifference > 10) { color = 'grey' }
+      if (yearDifference > 10) { color = 'grey' };
     }
 
     const percentagePlace = (startDate - BEGINNING_YEAR) / TIMELINE_LENGTH * this.state.timelineWidth;
@@ -61,16 +60,16 @@ class Timeline extends React.Component {
     return {
       placement: percentagePlace,
       width: yearWidth,
-      color
-    }
+      color,
+    };
   }
 
   handleMouseEnter(data) {
-    this.setState({ activeEvent: data })
+    this.setState({ activeEvent: data });
   }
 
   handleMouseLeave() {
-    this.setState({ clickIndex: null })
+    this.setState({ clickIndex: null });
   }
 
   handleKeyPress(data, e) {
@@ -79,19 +78,13 @@ class Timeline extends React.Component {
     }
   }
 
-  handleOnBlur() {
-    this.setState({ activeEvent: null });
-  }
-
   renderEvent(event, i) {
     const position = this.dateFinder(event.year);
-    const clicked = this.state.clickIndex == i ? true : false;
-    const data = { x: position.placement, event: event, i };
+    const data = { x: position.placement, event, i };
 
     return (
-      <g key={i} tabIndex={0} onKeyUp={this.handleKeyPress.bind(this, data)} onBlur={this.handleOnBlur} transform={`translate(${position.placement}, ${60})`} onMouseDown={this.handleMouseEnter.bind(this, data)} >
+      <g key={i} tabIndex={0} onKeyUp={this.handleKeyPress.bind(this, data)} transform={`translate(${position.placement}, ${60})`} onMouseDown={this.handleMouseEnter.bind(this, data)} >
         <line
-          ref={(c) => {this.test = c;} }
           className="event-line"
           x1="0" x2={position.width}
           y1="0" y2="0"
@@ -99,28 +92,28 @@ class Timeline extends React.Component {
           strokeWidth="25"
         />
       </g>
-    )
+    );
   }
 
   renderText() {
-    const data = this.state.activeEvent
-    const anchor = data.i == timelineEvents.length - 1 ? 'end' : 'start';
+    const data = this.state.activeEvent;
+    const anchor = data.i === timelineEvents.length - 1 ? 'end' : 'start';
 
     return (
       <Text textAnchor={anchor} x={data.x} y={100} year={data.event.year} width={200}>
         {data.event.text}
       </Text>
-    )
+    );
   }
 
   renderGroups(group, i) {
-    const test = this.dateFinder(group.years);
+    const date = this.dateFinder(group.years);
 
     return (
       <g key={i}>
-        <line x1={test.placement} y1="60" x2={test.placement + test.width} y2="60" strokeWidth={group.width} stroke="#F4F0E7" />
+        <line x1={date.placement} y1="60" x2={date.placement + date.width} y2="60" strokeWidth={group.width} stroke="#F4F0E7" />
       </g>
-    )
+    );
   }
 
   render() {
@@ -149,7 +142,7 @@ class Timeline extends React.Component {
             <line x1="100%" y1="55" x2="100%" y2="65" strokeWidth="5" stroke="gray" />
 
             {timelineEvents.map((event, i) => {
-              return this.renderEvent(event, i)
+              return this.renderEvent(event, i);
             })}
             {this.state.activeEvent && (
               this.renderText()

--- a/src/containers/ClassifierContainer.jsx
+++ b/src/containers/ClassifierContainer.jsx
@@ -99,7 +99,7 @@ class ClassifierContainer extends React.Component {
 
   render() {
     const activeCrop = this.props.viewerState === SUBJECTVIEWER_STATE.CROPPING ? 'active-crop' : '';
-    const disableAnnotate = this.props.selectedAnnotation !== null;
+    const disableTranscribe = this.props.selectedAnnotation !== null;
     const isAdmin = this.props.user && this.props.user.admin;
     const shownMarksClass = (MARKS_STATE.ALL === this.props.shownMarks) ? 'fa fa-eye' :
       (MARKS_STATE.USER === this.props.shownMarks) ? 'fa fa-eye-slash' : 'fa fa-eye-slash grey';
@@ -115,7 +115,7 @@ class ClassifierContainer extends React.Component {
           <div>
             <h2>directions</h2>
             <p>
-              Using the Annotate tool, click under the start and end of a line
+              Using the Transcribe tool, click under the start and end of a line
               of text, then add your transcription.
 
               {/*TEMPORARILY REMOVED: CRIBSHEET Clip common symbols or phrases to your
@@ -166,14 +166,14 @@ class ClassifierContainer extends React.Component {
             <h2>Toolbar</h2>
 
             <button
-              disabled={disableAnnotate}
+              disabled={disableTranscribe}
               className={(this.props.viewerState === SUBJECTVIEWER_STATE.ANNOTATING) ? 'flat-button block selected' : 'flat-button block'}
               onClick={this.useAnnotationTool}
             >
               <span className="classifier-toolbar__icon">
-                <i className={`fa fa-plus-circle ${disableAnnotate && 'disable-icon'}`} />
+                <i className={`fa fa-plus-circle ${disableTranscribe && 'disable-icon'}`} />
               </span>
-              <span>Annotate</span>
+              <span>Transcribe</span>
             </button>
 
             <button className="flat-button block" onClick={this.useRotate90}>

--- a/src/containers/ClassifierContainer.jsx
+++ b/src/containers/ClassifierContainer.jsx
@@ -348,8 +348,9 @@ class ClassifierContainer extends React.Component {
   }
 
   showMetadata() {
+    const metadata = (this.props.currentSubject && this.props.currentSubject.metadata) || {};
     this.props.dispatch(toggleDialog(
-      <ShowMetadata metadata={this.props.currentSubject.metadata} />, true, false, 'Subject Info'));
+      <ShowMetadata metadata={metadata} />, true, false, 'Subject Info'));
   }
 
   showShortcuts() {

--- a/src/containers/Navigator.jsx
+++ b/src/containers/Navigator.jsx
@@ -4,16 +4,11 @@ import { connect } from 'react-redux';
 import SVGImage from '../components/SVGImage';
 import { Utility } from '../lib/Utility';
 
-import {
-  setScaling, setTranslation,
-  setViewerState, updateViewerSize, updateImageSize,
-  SUBJECTVIEWER_STATE,
-} from '../ducks/subject-viewer';
+import { setTranslation } from '../ducks/subject-viewer';
 import { getSubjectLocation } from '../lib/get-subject-location';
 
 const SVG_WIDTH = 150;
 const SVG_HEIGHT = 150;
-const ZOOM_STEP = 0.1;
 
 class Navigator extends React.Component {
   constructor(props) {
@@ -27,17 +22,8 @@ class Navigator extends React.Component {
     //Other functions
     this.getBoundingBox = this.getBoundingBox.bind(this);
     this.clickZoom = this.clickZoom.bind(this);
-
   }
   //----------------------------------------------------------------
-
-  componentDidMount() {
-    this.svg.addEventListener('click', this.clickZoom);
-  }
-
-  componentWillUnmount() {
-    this.svg.addEventListener('click', this.clickZoom);
-  }
 
   clickZoom(e) {
     const boundingBox = this.getBoundingBox();
@@ -61,8 +47,8 @@ class Navigator extends React.Component {
     const inputY = (clientY - boundingBox.top) * sizeRatioY;
 
     if (this.props.imageSize.width !== 0 && this.props.imageSize.height !== 0) {
-      const centerX = this.props.imageSize.width / -2
-      const centerY = this.props.imageSize.height / -2
+      const centerX = this.props.imageSize.width / -2;
+      const centerY = this.props.imageSize.height / -2;
       const xScale = SVG_WIDTH / this.props.imageSize.width;
       const yScale = SVG_HEIGHT / this.props.imageSize.height;
       newX = centerX + (inputX / xScale);
@@ -84,13 +70,14 @@ class Navigator extends React.Component {
     if (this.props.currentSubject) {
       subjectLocation = getSubjectLocation(this.props.currentSubject, this.props.frame);
       subjectLocation = (subjectLocation && subjectLocation.src) ? subjectLocation.src : undefined;
-    };
+    }
 
     return (
       <section className="navigator-viewer" ref={(c) => { this.section = c; }}>
         <svg
           style={{ width: `${SVG_WIDTH}px`, height: `${SVG_HEIGHT}px` }}
           ref={(c) => { this.svg = c; }}
+          onMouseUp={this.clickZoom}
           viewBox={viewBox}
         >
           <g transform={rotate}>

--- a/src/containers/SubjectViewer.jsx
+++ b/src/containers/SubjectViewer.jsx
@@ -300,7 +300,7 @@ class SubjectViewer extends React.Component {
   /*  Once the Subject has been loaded properly, fit it into the SVG Viewer.
    */
   onImageLoad() {
-    if (this.svgImage.image) {
+    if (this.svgImage && this.svgImage.image) {
       const imgW = (this.svgImage.image.width) ? this.svgImage.image.width : 1;
       const imgH = (this.svgImage.image.height) ? this.svgImage.image.height : 1;
 

--- a/src/ducks/subject.js
+++ b/src/ducks/subject.js
@@ -116,15 +116,13 @@ const createFavorites = (project) => {
   const collection = {
     favorite: true,
     display_name,
-    links
+    links,
   };
   apiClient.type('collections')
     .create(collection)
     .save()
-    .catch((err) => {
-      reject(err);
-    })
-}
+    .catch(err => Promise.reject(err));
+};
 
 const toggleFavorite = () => {
   return (dispatch, getState) => {
@@ -215,7 +213,7 @@ const fetchSubject = (initialFetch = false) => {
     //   subjectQuery.subject_set_id = getState().subject.subjectSet;
     // }
     //----------------
-    
+
     console.info('ducks/subject.js fetchSubject(): subject_set_id ', subjectQuery.subject_set_id);
 
     const gsMode = getState().workflow.goldStandardMode;
@@ -233,7 +231,7 @@ const fetchSubject = (initialFetch = false) => {
             type: FETCH_SUBJECT_SUCCESS,
             favorite: currentSubject.favorite || false,
           });
-        
+
           console.info('ducks/subject.js fetchSubject() fetch subject success: subject id ', currentSubject.id);
           prepareForNewSubject(dispatch, currentSubject);
         })

--- a/src/index.tpl.html
+++ b/src/index.tpl.html
@@ -36,6 +36,6 @@
     <div id="root"></div>
     <%= htmlWebpackPlugin.options.gtm %>
 
-    <script src="https://ft-polyfill-service.herokuapp.com/v2/polyfill.min.js?features=default,es6,Array.prototype.includes,Array.prototype.keys,Promise.prototype.finally"></script>
+    <script src="https://ft-polyfill-service.herokuapp.com/v2/polyfill.min.js?features=default,es6,Array.prototype.includes,Array.prototype.keys"></script>
   </body>
 </html>

--- a/src/lib/timeline-events.js
+++ b/src/lib/timeline-events.js
@@ -1,64 +1,66 @@
-const timelineEvents = [{
+const timelineEvents = [
+  {
+    year: '1831-1866',
+    text: 'The Liberator is published weekly.',
+  },
+  {
     year: '1807',
     text: `Congress passes a law banning importation of new slaves into the
-      U.S. (effective January 1, 1808).`
+      U.S. (effective January 1, 1808).`,
   }, {
     year: '1819',
     text: `Elihu Embrue, a Quaker, founds the Manumission Intelligencier, an
-    abolitionist newspaper, later renamed The Emancipator.`
+    abolitionist newspaper, later renamed The Emancipator.`,
   }, {
     year: '1820',
     text: `South Carolina institutes penalties for anyone caught bringing
-    anti-slavery materials into the state.`
+    anti-slavery materials into the state.`,
   }, {
     year: '1827',
-    text: `Peter Williams, Jr. founds / Freedom’s Journal/, the first
-    African-American owned and operated newspaper in the U.S.`
+    text: `Peter Williams, Jr. founds Freedom’s Journal, the first
+    African-American owned and operated newspaper in the U.S.`,
   }, {
     year: '1831',
     text: `The New England Anti-Slavery Society is founded in Boston. Its
     principal founder is William Lloyd Garrison, who begins publication of the
-    newspaper, The Liberator.`
-  }, {
-    year: '1831-1866',
-    text: `The Liberator is published weekly.`
+    newspaper, The Liberator.`,
   }, {
     year: '1838',
     text: `Formal organization of the Underground Railroad,
-    led by African-American abolitionist Robert Purvis.`
+    led by African-American abolitionist Robert Purvis.`,
   }, {
     year: '1845',
-    text: `Narrative of the Life of Frederick Douglass is published.`
+    text: 'Narrative of the Life of Frederick Douglass is published.',
   }, {
     year: '1847',
     text: `Frederick Douglass begins publishing The North Star, an anti-slavery
-    newspaper, in Rochester, NY.`
+    newspaper, in Rochester, NY.`,
   }, {
     year: '1857',
     text: `Dred Scott decision, in which the U.S. Supreme Court rules in the
     case of Scott v. Sanford that black people are not U.S. citizens and possess
     no constitutional rights. The decision also allows slaveholders to take slaves
-    into free areas of the United States.`
+    into free areas of the United States.`,
   }, {
     year: '1860',
-    text: `Abraham Lincoln is elected president of the United States.`
+    text: 'Abraham Lincoln is elected president of the United States.',
   }, {
     year: '1861-1865',
-    text: 'Civil War'
+    text: 'Civil War',
   }, {
     year: '1868',
     text: `The 14th Amendment to the U.S. Constitution is passed, ensuring
     citizenship to all people born in the United States, and protecting the
     privileges of U.S. Citizens. This amendment also overturned the Supreme
-    Court ruling in the Dred Scott decision.`
+    Court ruling in the Dred Scott decision.`,
   }, {
     year: '1885',
-    text: `Abolitionist leader, journalist, editor, Maria Weston Chapman, dies.`
+    text: 'Abolitionist leader, journalist, editor, Maria Weston Chapman, dies.',
   }, {
     year: '1909',
     text: `National Association for the Advancement of Colored People (NAACP) is
-    founded in New York City.`
-  }
+    founded in New York City.`,
+  },
 ];
 
 export default timelineEvents;

--- a/src/styles/components/font-groups.styl
+++ b/src/styles/components/font-groups.styl
@@ -55,6 +55,7 @@
   font-family: $playfair-display
   font-size: 14px
   letter-spacing: 2px
+  text-transform: uppercase
 
 .text-links
   font-family: $playfair-display

--- a/src/styles/components/home-page.styl
+++ b/src/styles/components/home-page.styl
@@ -37,6 +37,13 @@
       &:hover, &:focus
         border-bottom: 2px solid $eggplant
 
+    .home-page__body-text
+      text-align: center
+
+      span
+        display: block
+        margin-top: 0.5em
+
   &__progress-bar
     background: $light-eggplant
     display: flex
@@ -278,4 +285,4 @@
   font-size: 0.85em
 
   input
-    margin: 0.5em  
+    margin: 0.5em


### PR DESCRIPTION
This PR covers several items:

- Tweaks content, including typos
- Adjusts some problems with the timeline (the long gray event covering up another event, having to double click to activate an event)
- Adds note on landing page about mobile devices and tablets
- Solves some linter errors as they appear
- Fixes some existence issues on several components that appeared via Rollbar
- Adds links to Subjects of Note on landing page
- Removes the `finally()` polyfill, which is no longer needed

Closes #239 