### PR TITLE
Add Content and URL to About Page

### DIFF
--- a/src/components/AboutTheProject.jsx
+++ b/src/components/AboutTheProject.jsx
@@ -60,6 +60,31 @@ class AboutTheProject extends React.Component {
             the 1870s.
           </span>
 
+          <span>
+            The primary production goal of this project is to gain a complete corpus
+            of machine-readable text from these handwritten documents. There are
+            no software programs that can accurately convert handwriting into
+            characters that a computer can understand as an actual letter, number,
+            or symbol. Once the documents have all been transcribed and converted
+            into this machine-readable text, we will upload the text into our
+            <a
+              href="https://www.digitalcommonwealth.org/collections/commonwealth:ht24xg10q"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              repository system
+            </a>
+            and index them along with their corresponding image files. Users will
+            then be able to search the full text of the letters across the entire collection.
+          </span>
+
+          <span>
+            We also plan to make the transcriptions available as a complete, open
+            access data set, with the intention that the corpus will be exposed
+            to machine learning, topic modeling, and other natural language processing
+            and computer visualization applications.
+          </span>
+
           <a href="https://www.digitalcommonwealth.org/collections/commonwealth:ht24xg10q" rel="noopener noreferrer" target="_blank">View Collection</a>
         </div>
 

--- a/src/styles/components/about-project.styl
+++ b/src/styles/components/about-project.styl
@@ -44,6 +44,16 @@
     @media(max-width: 500px)
       margin: 1em 2em
 
+    span a
+      border-bottom: 2px solid $dark-grey
+      cursor: pointer
+      font-family: cormorant-font
+      font-size: 0.9em
+      letter-spacing: inherit
+      line-height: 1.2em
+      margin: 0 0.25em
+      text-transform: none
+
   &__team
     background-color: $sandy
     margin: 4em


### PR DESCRIPTION
This adds some content to the about the project page explaining to users what we plan to do with the transcribed text.