### PR TITLE
Update text for when Classifications fail to better reflect reality

### DIFF
--- a/src/ducks/classifications.js
+++ b/src/ducks/classifications.js
@@ -162,7 +162,7 @@ const saveAllQueuedClassifications = (dispatch, user = null) => {
         //Did anything fail?
         if (itemsFailed > 0) {
           //TODO: better presentation
-          alert('Your Transcription could not be submitted at this time. However, we\'ve saved your work on this computer, so please refresh the page to recover your work. The next time you submit a Transcription, all previous work will be resubmitted.');
+          alert('Your Transcription could not be submitted at this time. However, we\'ve saved your work on this computer and it will automatically be resubmitted the next time you submit a Transcription. Please refresh the page to start working on a new letter.');
         }
 
         //Save the new queue.


### PR DESCRIPTION
## PR Update
This PR changes the text the user sees when `submitClassification()` fails, to avoid confusion on what's happening and what the user should do.

Previously:
_"Your Transcription could not be submitted at this time. However, we've saved your work on this computer and it will automatically be resubmitted the next time you submit a Transcription. Please refresh the page to start working on a new letter."_

Now:
_"Your Transcription could not be submitted at this time. However, we've saved your work on this computer and it will automatically be resubmitted the next time you submit a Transcription. Please refresh the page to start working on a new letter."_

### Status
Text update, self-merging.