### PR TITLE
getSessionID() should compare integer representations of Date objects

### DIFF
--- a/src/lib/get-session-id.js
+++ b/src/lib/get-session-id.js
@@ -22,7 +22,7 @@ const getSessionID = () => {
     ({id, ttl} = JSON.parse(sessionStorage.getItem('session_id')));
   }
 
-  if (ttl < Date.now()) {
+  if (new Date(ttl).getTime() < Date.now()) {
     id = generateSessionID();
   } else {
     ttl = fiveMinutesFromNow();

--- a/src/lib/get-session-id.js
+++ b/src/lib/get-session-id.js
@@ -4,7 +4,7 @@ const generateSessionID = () => {
   const hash = require('hash.js');
   const sha2 = hash.sha256();
   const id = sha2.update(`${Math.random() * 10000 }${Date.now()}${Math.random() * 1000}`).digest('hex');
-  const ttl = fiveMinutesFromNow();
+  const ttl = twoHoursFromNow();
   const stored = {id, ttl};
   try {
     sessionStorage.setItem('session_id', JSON.stringify(stored));
@@ -25,7 +25,7 @@ const getSessionID = () => {
   if (new Date(ttl).getTime() < Date.now()) {
     id = generateSessionID();
   } else {
-    ttl = fiveMinutesFromNow();
+    ttl = twoHoursFromNow();
     try {
       sessionStorage.setItem('session_id', JSON.stringify({id, ttl}))
     }
@@ -39,6 +39,12 @@ const getSessionID = () => {
 const fiveMinutesFromNow = () => {
   const d = new Date();
   d.setMinutes(d.getMinutes() + 5);
+  return d;
+};
+
+const twoHoursFromNow = () => {
+  const d = new Date();
+  d.setHours(d.getHours() + 2);
   return d;
 };
 


### PR DESCRIPTION
While adding the get-session-id.js file to Ancient Lives, I noticed in `#getSessionID()` that `ttl < Date.now()` never returned true.
https://github.com/zooniverse/anti-slavery-manuscripts/blob/6b3aee3c51cb26273b20664bb218a946581000d4/src/lib/get-session-id.js#L25-L26
The method is comparing a string representation of a Date object with a number representation of a Date object. This PR makes a small adjustment so that integer value representations are compared instead.