### PR TITLE
Update Button Text and Add Announcement Banner

### DIFF
--- a/src/components/Banner.jsx
+++ b/src/components/Banner.jsx
@@ -2,20 +2,18 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Banner = ({ hideBanner }) => {
-  //If no messages, just return null.
-  return null;
-  
-  /*
+  // If no messages, just return null.
+  // return null;
+
   return (
     <div className="top-banner">
       <h2>
-        Thanks for participating in our beta review! We're making some changes
-        based on your feedback, and will be launching the full project soon!
+        Thank you for participating! We appreciate any feedback for our workflow selection option
+        <a href="https://goo.gl/forms/j7HaJMMTPkV4kd5w2" target="blank" rel="noopener noreferrer">here</a>.
       </h2>
       <button onClick={hideBanner}>X</button>
     </div>
   );
-  */
 };
 
 Banner.propTypes = {

--- a/src/containers/ClassifierContainer.jsx
+++ b/src/containers/ClassifierContainer.jsx
@@ -137,7 +137,7 @@ class ClassifierContainer extends React.Component {
           <div className="header-panel">Choose how you would like to transcribe</div>
           <div className="button-panel">
             <button className="white-green button" onClick={() => { startWorkflow(config.zooniverseLinks.workflowId, VARIANT_TYPES.INDIVIDUAL) }}>
-              Solo
+              Independent
             </button>
             <button className="white-green button" onClick={() => { startWorkflow(config.zooniverseLinks.collabWorkflowId, VARIANT_TYPES.COLLABORATIVE) }}>
               Collaborative

--- a/src/containers/ClassifierContainer.jsx
+++ b/src/containers/ClassifierContainer.jsx
@@ -192,10 +192,10 @@ class ClassifierContainer extends React.Component {
 
     const currentMode = this.props.variant === VARIANT_TYPES.COLLABORATIVE ?
       'Collaborative' :
-      'Solo';
+      'Independent';
     const toggleMode = this.props.variant === VARIANT_TYPES.INDIVIDUAL ?
       'Collaborative' :
-      'Solo';
+      'Independent';
 
     return (
       <main className="app-content classifier-page flex-row">

--- a/src/styles/components/top-banner.styl
+++ b/src/styles/components/top-banner.styl
@@ -14,10 +14,13 @@
     color: white
     cursor: pointer
     font-size: 1.25em
-    margin: 0 0.5em 0 auto
 
   h2
-    margin: 0
+    margin: 0 auto
+
+  a
+    margin-left: 0.25rem
+    text-decoration: underline
 
 .popup.popup-sign-in-prompt
   z-index: 100  //Place the prompt above the ZRC Tutorial.


### PR DESCRIPTION
This PR comes on the heels of #262 and makes two changes.

- Adjusts the button text from "solo" to ~~"collaborative"~~ "independent" for the workflow selection button to keep naming consistent. 

- Reintroduces the announcement banner to the top of ASM notifying users of the feedback form.