### PR TITLE
Disable Done Button With Empty Transcription

### DIFF
--- a/src/components/SelectedAnnotation.jsx
+++ b/src/components/SelectedAnnotation.jsx
@@ -159,6 +159,8 @@ class SelectedAnnotation extends React.Component {
   }
 
   render() {
+    const disableDone = this.state.annotationText.length === 0;
+
     let instructions = 'Please transcribe all of the words in the line of text.';
     if (this.props.variant === VARIANT_TYPES.COLLABORATIVE) {
       instructions += ` Open the dropdown menu to use previous volunteers'
@@ -244,7 +246,7 @@ class SelectedAnnotation extends React.Component {
           )}
 
           <div className="selected-annotation__buttons">
-            <button className="done-button" onClick={this.saveText}>Done</button>
+            <button className="done-button" disabled={disableDone} onClick={this.saveText}>Done</button>
             <button onClick={this.cancelAnnotation}>Cancel</button>
             {(this.props.annotation.previousAnnotation) ? null :
               <button onClick={this.deleteAnnotation}>Delete</button>


### PR DESCRIPTION
There's a bug in the transcription interface where users are able to select "done" on a transcription pane when there is no text in the input box. This can lead to a confusing UI where users may think they are selecting and recording annotations that are actually empty. This was first  found in [this](https://www.zooniverse.org/projects/bostonpubliclibrary/anti-slavery-manuscripts/talk/1183/647976) talk post. 