### PR TITLE
Find Annotation to Delete By Points

### DIFF
--- a/src/components/SelectedAnnotation.jsx
+++ b/src/components/SelectedAnnotation.jsx
@@ -256,14 +256,14 @@ class SelectedAnnotation extends React.Component {
   }
 
   cancelAnnotation() {
-    //Cancelling a new Annotation (i.e. it starts off with empty text) should also delete it.
+    // Cancelling a new Annotation (i.e. it starts off with empty text) should also delete it.
     const initialAnnotationText =
       (this.props.selectedAnnotation && this.props.selectedAnnotation.details &&
        this.props.selectedAnnotation.details[0] && this.props.selectedAnnotation.details[0].value)
-      ? this.props.selectedAnnotation.details[0].value : '';
+        ? this.props.selectedAnnotation.details[0].value : '';
 
     if (initialAnnotationText.trim().length === 0) {
-      this.deleteAnnotation();  //Cancel this action and delete this newly created Annotation.
+      this.deleteAnnotation();
     } else {
       if (this.props.onClose) { this.props.onClose(); }  //Cancel this action and make no updates to the existing (and valid) Annotation.
     }
@@ -288,14 +288,14 @@ class SelectedAnnotation extends React.Component {
   }
 
   saveText() {
-    //There are two possibilities here: either the user is agreeing with a
-    //Previous (Aggregated) Annotation, or the user is creating/editing their
-    //own.
+    // There are two possibilities here: either the user is agreeing with a
+    // Previous (Aggregated) Annotation, or the user is creating/editing their
+    // own.
     if (this.props.annotation.previousAnnotation) {
       this.props.dispatch(collaborateWithAnnotation(this.props.annotation, this.state.annotationText));
       this.props.dispatch(updatePreviousAnnotation(this.props.selectedAnnotationIndex));
     } else {
-      //If the newly updated annotation text is essentially blank, just delete this whole Annotation line.
+      // If the newly updated annotation text is essentially blank, just delete this whole Annotation line.
       const text = (this.state.annotationText && this.state.annotationText.trim)
         ? this.state.annotationText.trim() : '';
       if (text !== '') {
@@ -366,6 +366,8 @@ SelectedAnnotation.defaultProps = {
 SelectedAnnotation.propTypes = {
   annotation: PropTypes.shape({
     details: React.PropTypes.array,
+    previousAnnotation: React.PropTypes.bool,
+    textOptions: React.PropTypes.array,
   }),
   annotationPanePosition: PropTypes.shape({
     x: PropTypes.number,
@@ -392,7 +394,7 @@ SelectedAnnotation.contextTypes = {
   googleLogger: PropTypes.object,
 };
 
-const mapStateToProps = (state, ownProps) => {
+const mapStateToProps = (state) => {
   const sv = state.subjectViewer;
   return {
     annotationPanePosition: state.annotations.annotationPanePosition,

--- a/src/ducks/annotations.js
+++ b/src/ducks/annotations.js
@@ -4,7 +4,7 @@ Redux Duck: Annotations
  */
 import { SUBJECTVIEWER_STATE, setViewerState } from './subject-viewer';
 
-//Action Types
+// Action Types
 const RESET_ANNOTATIONS = 'RESET_ANNOTATIONS';
 const ADD_ANNOTATION_POINT = 'ADD_ANNOTATION_POINT';
 const COMPLETE_ANNOTATION = 'COMPLETE_ANNOTATION';
@@ -15,7 +15,7 @@ const COLLABORATE_WITH_ANNOTATION = 'COLLABORATE_WITH_ANNOTATION';
 const UPDATE_TEXT = 'UPDATE_TEXT';
 const SET_ANNOTATIONS = 'SET_ANNOTATIONS';
 
-//Misc Constants
+// Misc Constants
 const ANNOTATION_STATUS = {
   IDLE: 'annotation_status_idle',
   IN_PROGRESS: 'annotation_status_in_progress',
@@ -23,7 +23,7 @@ const ANNOTATION_STATUS = {
 
 //------------------------------------------------------------------------------
 
-//Reducer
+// Reducer
 
 //Note: a single Annotation should look like this:
 //{ text: "Example text",
@@ -34,10 +34,10 @@ const ANNOTATION_STATUS = {
 
 const initialState = {
   status: ANNOTATION_STATUS.IDLE,
-  annotationInProgress: null,  //Incomplete annotation. null if nothing is in progress.
+  annotationInProgress: null,
   annotationPanePosition: null,
-  annotations: [],  //Completed annotations.
-  selectedAnnotation: null,  //Existing annotation that's been selected, by clicking on them. null if nothing is selected.
+  annotations: [],
+  selectedAnnotation: null,
   selectedAnnotationIndex: null,
 };
 
@@ -48,8 +48,8 @@ const annotationsReducer = (state = initialState, action) => {
 
     case ADD_ANNOTATION_POINT:
       const annotationInProgress = (state.annotationInProgress)
-        ? Object.assign({}, state.annotationInProgress) //Create a copy, don't modify the existing object.
-        : { details: [{value: ''}], points: [], frame: action.frame };
+        ? Object.assign({}, state.annotationInProgress) // Create a copy, don't modify the existing object.
+        : { details: [{ value: '' }], points: [], frame: action.frame };
       annotationInProgress.points.push({ x: action.x, y: action.y });
       return Object.assign({}, state, {
         status: ANNOTATION_STATUS.IN_PROGRESS,
@@ -67,8 +67,8 @@ const annotationsReducer = (state = initialState, action) => {
         annotationInProgress: null,
         annotations,
         annotationPanePosition: endPoint,
-        selectedAnnotation: state.annotationInProgress,  //Auto-select latest annotation.
-        selectedAnnotationIndex: annotations.length - 1
+        selectedAnnotation: state.annotationInProgress,
+        selectedAnnotationIndex: annotations.length - 1,
       });
 
     case SELECT_ANNOTATION:
@@ -87,46 +87,52 @@ const annotationsReducer = (state = initialState, action) => {
       const newAnnotation = {
         details: [{ value: action.text }],
         points: action.annotation.points,
-        frame: action.annotation.frame
+        frame: action.annotation.frame,
       };
       userAnnotations.push(newAnnotation);
 
       return Object.assign({}, state, {
-        annotations: userAnnotations
+        annotations: userAnnotations,
       });
 
     case SET_ANNOTATIONS:
       return Object.assign({}, state, {
-        annotations: action.annotations
+        annotations: action.annotations,
       });
 
     case UPDATE_TEXT:
-      const newDetails = [{value: action.text}];
+      const newDetails = [{ value: action.text }];
       const annotationCopy = state.annotations.slice();
       const updatedAnnotation = annotationCopy[state.selectedAnnotationIndex];
       updatedAnnotation.details = newDetails;
 
       return Object.assign({}, state, {
-        annotations: annotationCopy
+        annotations: annotationCopy,
       });
 
     case UNSELECT_ANNOTATION:
       return Object.assign({}, state, {
         annotationPanePosition: null,
         selectedAnnotation: null,
-        selectedAnnotationIndex: null
+        selectedAnnotationIndex: null,
       });
 
     case DELETE_SELECTED_ANNOTATION:
       let filteredAnnotations = [];
-      if (state.annotations && state.selectedAnnotationIndex !== null) {
-        filteredAnnotations = state.annotations.filter((item, index) => {
-          return index !== state.selectedAnnotationIndex;
+      if (state.annotations && state.selectedAnnotation) {
+        filteredAnnotations = state.annotations.filter((item) => {
+          let shouldRemove = false;
+          item.points.map((a, i) => {
+            const b = state.selectedAnnotation.points[i];
+            shouldRemove = a.x === b.x && a.y === b.y;
+          });
+          return !shouldRemove;
         });
+      } else if (state.annotations) {
+        filteredAnnotations = state.annotations;
       }
       return Object.assign({}, state, {
         annotations: filteredAnnotations,
-        //Note: delete_selected_annotation also performs unselect_annotation.
         annotationPanePosition: null,
         selectedAnnotation: null,
         selectedAnnotationIndex: null,
@@ -139,7 +145,7 @@ const annotationsReducer = (state = initialState, action) => {
 
 //------------------------------------------------------------------------------
 
-//Action Creators
+// Action Creators
 
 const resetAnnotations = () => {
   return (dispatch) => {
@@ -151,7 +157,9 @@ const addAnnotationPoint = (x, y, frame) => {
   return (dispatch) => {
     dispatch({
       type: ADD_ANNOTATION_POINT,
-      x, y, frame
+      x,
+      y,
+      frame,
     });
   };
 };
@@ -212,7 +220,7 @@ const updateText = (text) => {
   return (dispatch) => {
     dispatch({
       type: UPDATE_TEXT,
-      text
+      text,
     });
   };
 };
@@ -221,7 +229,8 @@ const collaborateWithAnnotation = (annotation, text) => {
   return (dispatch) => {
     dispatch({
       type: COLLABORATE_WITH_ANNOTATION,
-      annotation, text
+      annotation,
+      text,
     });
   };
 };
@@ -230,7 +239,7 @@ const setAnnotations = (annotations) => {
   return (dispatch) => {
     dispatch({
       type: SET_ANNOTATIONS,
-      annotations
+      annotations,
     });
   };
 };
@@ -239,7 +248,7 @@ export default annotationsReducer;
 
 //------------------------------------------------------------------------------
 
-//Exports
+// Exports
 
 export {
   resetAnnotations, setAnnotations,

--- a/src/ducks/previousAnnotations.js
+++ b/src/ducks/previousAnnotations.js
@@ -6,7 +6,7 @@ const FETCH_ANNOTATIONS = 'FETCH_ANNOTATIONS';
 const FETCH_ANNOTATIONS_SUCCESS = 'FETCH_ANNOTATIONS_SUCCESS';
 const FETCH_ANNOTATIONS_ERROR = 'FETCH_ANNOTATIONS_ERROR';
 
-const UPDATE_FRAME ='UPDATE_FRAME';
+const UPDATE_FRAME = 'UPDATE_FRAME';
 const UPDATE_PREVIOUS_ANNOTATION = 'UPDATE_PREVIOUS_ANNOTATION';
 const REENABLE_PREVIOUS_ANNOTATION = 'REENABLE_PREVIOUS_ANNOTATION';
 
@@ -28,27 +28,27 @@ const previousAnnotationsReducer = (state = initialState, action) => {
   switch (action.type) {
     case FETCH_ANNOTATIONS:
       return Object.assign({}, state, {
-        data: null,  //Reset
-        marks: [],  //Reset
-        selectedPreviousAnnotation: null,  //Reset
-        status: PREVIOUS_ANNOTATION_STATUS.FETCHING
+        data: null,
+        marks: [],
+        selectedPreviousAnnotation: null,
+        status: PREVIOUS_ANNOTATION_STATUS.FETCHING,
       });
 
     case FETCH_ANNOTATIONS_SUCCESS:
       return Object.assign({}, state, {
         data: action.data,
         marks: action.marks,
-        status: PREVIOUS_ANNOTATION_STATUS.READY
+        status: PREVIOUS_ANNOTATION_STATUS.READY,
       });
 
     case FETCH_ANNOTATIONS_ERROR:
       return Object.assign({}, state, {
-        status: PREVIOUS_ANNOTATION_STATUS.ERROR
+        status: PREVIOUS_ANNOTATION_STATUS.ERROR,
       });
 
     case UPDATE_FRAME:
       return Object.assign({}, state, {
-        marks: action.marks
+        marks: action.marks,
       });
 
     case UPDATE_PREVIOUS_ANNOTATION:
@@ -57,25 +57,24 @@ const previousAnnotationsReducer = (state = initialState, action) => {
       updatedAnnotation.hasCollaborated = true;
 
       return Object.assign({}, state, {
-        marks
+        marks,
       });
 
     case REENABLE_PREVIOUS_ANNOTATION:
-      //Find the Previous (Aggregated) Annotation that matches the Selected Annotation, then reenable it.
       const reenabledMarks = state.marks.map((item) => {
-        let isAMatch =  //First check: does the current Previous Annotation and the Selected Annotation look remotely similar?
+        let isAMatch =  // First check: does the current Previous Annotation and the Selected Annotation look remotely similar?
           item.hasCollaborated && item.points &&
           action.selectedAnnotation && action.selectedAnnotation.points &&
           item.points.length === action.selectedAnnotation.points.length;
 
-        if (isAMatch) {  //Second check: do all the x-y coordinates that make the line match up?
+        if (isAMatch) {  // Second check: do all the x-y coordinates that make the line match up?
           item.points.map((a, index) => {
             const b = action.selectedAnnotation.points[index];
             isAMatch = isAMatch && a.x === b.x && a.y === b.y;
           });
         }
 
-        //Finally, reenable the Previous Annotation if it's a match.
+        // Finally, reenable the Previous Annotation if it's a match.
         if (isAMatch) item.hasCollaborated = false;
 
         //WARNING: This is a fairly primitive method of reenabling the previous
@@ -89,9 +88,9 @@ const previousAnnotationsReducer = (state = initialState, action) => {
         marks: reenabledMarks,
       });
 
-   default:
-     return state;
- };
+    default:
+      return state;
+  }
 };
 
 const fetchPreviousAnnotations = (subject) => {
@@ -119,13 +118,13 @@ const fetchPreviousAnnotations = (subject) => {
       dispatch({
         type: FETCH_ANNOTATIONS_SUCCESS,
         data: data.workflow.subject_reductions,
-        marks
+        marks,
       });
     })
-    .catch((err) => {
-      console.error('ducks/previousAnnotations.js fetchPreviousAnnotations() error: ', err);
-      dispatch({ type: FETCH_ANNOTATIONS_ERROR });
-    });
+      .catch((err) => {
+        console.error('ducks/previousAnnotations.js fetchPreviousAnnotations() error: ', err);
+        dispatch({ type: FETCH_ANNOTATIONS_ERROR });
+      });
   };
 };
 
@@ -149,7 +148,7 @@ const reenablePreviousAnnotation = () => {
       selectedAnnotation,
     });
   };
-}
+};
 
 const changeFrameData = (index) => {
   return (dispatch, getState) => {
@@ -157,7 +156,7 @@ const changeFrameData = (index) => {
     const marks = constructAnnotations(data, index);
     dispatch({
       type: UPDATE_FRAME,
-      marks
+      marks,
     });
   };
 };
@@ -165,7 +164,7 @@ const changeFrameData = (index) => {
 
 const constructAnnotations = (reductions, frame) => {
   const clusteredAnnotations = reductions || [];
-  let previousAnnotations = [];
+  const previousAnnotations = [];
   clusteredAnnotations.map((reduction) => {
     const currentFrameAnnotations = reduction.data[`frame${frame}`];
 
@@ -174,15 +173,17 @@ const constructAnnotations = (reductions, frame) => {
         const points = constructCoordinates(annotation);
         const textOptions = constructText(annotation, i);
         const data = {
-          points, frame, textOptions,
+          points,
+          frame,
+          textOptions,
           consensusReached: annotation.consensus_score >= CONSENSUS_SCORE,
           previousAnnotation: true,
           hasCollaborated: false,
         };
         previousAnnotations.push(data);
-      })
+      });
     }
-  })
+  });
   return previousAnnotations;
 };
 


### PR DESCRIPTION
Closes #270 

This solves the issue of users accidentally deleting their previous annotations. 

Previously, selected annotations were deleted by matching the `selectedAnnotationIndex` with the same index in the completed annotations array. This caused issues when the selected annotation was a previous annotation (red line) because the `selectedAnnotationIndex` would incorrectly be calculated in relation to other red lines instead of in relation to blue (user) lines.

Instead of using index numbers, a selected annotation is now deleted by matching it with the correct points of all user annotations. 

Some changes in this PR also attempt to get rid of linter errors.