### PR TITLE
Fix missing "Resume Progress" popup - don't render app until login is initialised

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -97,7 +97,7 @@ class App extends React.Component {
   }
 
   render() {
-    if (this.props.projectStatus !== PROJECT_STATUS.READY) {
+    if (this.props.projectStatus !== PROJECT_STATUS.READY || !this.props.initialised) {
       return <LoadingSpinner />
     }  //TODO: Consider what to do for STATUS: ERROR
 


### PR DESCRIPTION
## PR Overview
This PR fixes an issue where the Resume Progress popup doesn't show, even if the user has Saved Work In Progress (as shown in the browser cookies). Turns out the problem is that sometimes the Classifier page attempts to find a user's work in progress before realising if there's a user to begin with.

See #274 for more details.

Fixes #274 

In any case, this initialisation check is good practise for _all our projects_ as the whole _point_ of the `.initialised` parameter is to tell the app that it's ready to render (at least in terms of user login checks).

Note to self: check out projects to ensure that this is also in place.

### Status
@wgranger this is ready for review. If everything's OK, can you also please help deploy the fix? I need to head off shortly-ish.

Tagging @snblickhan so we can update our volunteers later.