### PR TITLE
Remove Workflow Selection

### DIFF
--- a/src/components/SelectedAnnotation.jsx
+++ b/src/components/SelectedAnnotation.jsx
@@ -75,8 +75,8 @@ class SelectedAnnotation extends React.Component {
     let textAfter;
     let textInBetween;
 
-    const startTag = '[' + textTag + ']';
-    const endTag = '[/' + textTag + ']';
+    const startTag = `[${textTag}]`;
+    const endTag = `[/${textTag}]`;
     const text = this.inputText;
     const textAreaValue = text.value;
     const selectionStart = text.selectionStart;
@@ -220,6 +220,7 @@ class SelectedAnnotation extends React.Component {
             <button onClick={this.insertTextModifier.bind(this, 'deletion')}>[deletion]</button>
             <button onClick={this.insertTextModifier.bind(this, 'unclear')}>[unclear]</button>
             <button onClick={this.insertTextModifier.bind(this, 'underline')}>[underline]</button>
+            <button onClick={this.insertTextModifier.bind(this, 'table')}>[table]</button>
           </div>
 
           <p>

--- a/src/containers/ClassifierContainer.jsx
+++ b/src/containers/ClassifierContainer.jsx
@@ -77,7 +77,6 @@ class ClassifierContainer extends React.Component {
     dispatch(fetchGuide());
     document.addEventListener('keyup', this.handleKeyUp);
 
-    //FUTURE UPDATE:
     //Select only one workflow
     //----------------------------------------------------------------
     dispatch(fetchWorkflow(config.zooniverseLinks.collabWorkflowId)).then(() => {
@@ -289,14 +288,6 @@ class ClassifierContainer extends React.Component {
             {this.state.popup}
           </Popup>
         }
-
-        {/*
-        //FUTURE UPDATE:
-        //Select only one workflow
-        //----------------------------------------------------------------
-        this.renderSignInReminder()
-        //----------------------------------------------------------------
-        */}
 
       </main>
     );

--- a/src/containers/ClassifierContainer.jsx
+++ b/src/containers/ClassifierContainer.jsx
@@ -121,6 +121,7 @@ class ClassifierContainer extends React.Component {
   render() {
     // Status Checks
     //----------------------------------------------------------------
+
     if (this.props.workflowStatus === WORKFLOW_STATUS.FETCHING) {
       return (
         <main className="app-content classifier-page-panel flex-column flex-center">
@@ -155,6 +156,10 @@ class ClassifierContainer extends React.Component {
 
     return (
       <main className="app-content classifier-page flex-row">
+        {!this.props.user && (
+          this.renderSignInReminder()
+        )}
+
         <div className="project-background"></div>
         <section id="help-column" className="help-pane">
           <div>

--- a/src/containers/ClassifierContainer.jsx
+++ b/src/containers/ClassifierContainer.jsx
@@ -80,10 +80,9 @@ class ClassifierContainer extends React.Component {
     //FUTURE UPDATE:
     //Select only one workflow
     //----------------------------------------------------------------
-    //dispatch(fetchWorkflow(config.zooniverseLinks.collabWorkflowId)).then(() => {
-    //  dispatch(fetchSubject());
-    //  dispatch(setVariant(VARIANT_TYPE.COLLABORATIVE));
-    //});
+    dispatch(fetchWorkflow(config.zooniverseLinks.collabWorkflowId)).then(() => {
+      dispatch(fetchSubject());
+    });
     //----------------------------------------------------------------
 
     //Saved Progress Check
@@ -120,61 +119,12 @@ class ClassifierContainer extends React.Component {
   }
 
   render() {
-    //JULY UPDATE:
-    //Allow users to select their workflow
-    //----------------------------------------------------------------
-    const startWorkflow = (workflow_id, variant_type) => {
-      this.props.dispatch(fetchWorkflow(workflow_id)).then(() => {
-        this.props.dispatch(fetchSubject());
-        this.props.dispatch(setVariant(variant_type));
-      });
-    }
-
-    if (this.props.workflowStatus === WORKFLOW_STATUS.IDLE) {
-      return (
-        <main className="app-content classifier-page-panel flex-column flex-center">
-          <div className="project-background" />
-          <div className="header-panel">Choose how you would like to transcribe</div>
-          <div className="button-panel flex-row">
-            <div className="flex-column">
-              <button className="white-green button" disabled onClick={() => { startWorkflow(config.zooniverseLinks.workflowId, VARIANT_TYPES.INDIVIDUAL) }}>
-                Independent
-              </button>
-              <span>Under maintenance</span>
-            </div>
-            <div className="flex-column">
-              <button className="white-green button" disabled onClick={() => { startWorkflow(config.zooniverseLinks.collabWorkflowId, VARIANT_TYPES.COLLABORATIVE) }}>
-                Collaborative
-              </button>
-              <span>New subjects coming soon</span>
-            </div>
-          </div>
-          <div className="details-panel">
-            <p>When we first launched this project, we ran an A/B experiment to research what method of transcription produces the highest-quality results. You can read more about this ongoing research on the project <a href="https://www.bpl.org/distinction/tag/anti-slavery-manuscripts/" target="blank" rel="noopener noreferrer">blog.</a></p>
-            <p>Now that the experiment has finished, we are curious to know what you, our volunteers, think of each method. For the next month, you will have the option to choose between <b>Independent</b> and <b>Collaborative</b> transcription methods.</p>
-            <p>The <b>Collaborative</b> option allows you to see other volunteers' transcriptions. The <b>Independent</b> option allows volunteers to transcribe independently. Please read the tutorial before participating in an unfamiliar method, as the transcription process differs for each method.</p>
-            <p>We'd love to hear your thoughts about the methods: you can give us feedback on the workflows <a href="https://goo.gl/forms/j7HaJMMTPkV4kd5w2" target="blank" rel="noopener noreferrer">here</a>; additionally, you can visit the project <a href="https://www.zooniverse.org/projects/bostonpubliclibrary/anti-slavery-manuscripts/talk" target="blank" rel="noopener noreferrer">Talk</a> board to chat with other volunteers about this process and ask questions of the research team.</p>
-            <p>Thanks, and happy transcribing!</p>
-        </div>
-
-          {(this.state.popup === null) ? null :
-            <Popup onClose={this.closePopup.bind(this)}>
-              {this.state.popup}
-            </Popup>
-          }
-
-          {this.renderSignInReminder()}
-        </main>
-      );
-    }
-    //----------------------------------------------------------------
-
-    //Status Checks
+    // Status Checks
     //----------------------------------------------------------------
     if (this.props.workflowStatus === WORKFLOW_STATUS.FETCHING) {
       return (
         <main className="app-content classifier-page-panel flex-column flex-center">
-          <div className="loading-spinner"></div>
+          <div className="loading-spinner" />
         </main>
       );
     }

--- a/src/containers/ClassifierContainer.jsx
+++ b/src/containers/ClassifierContainer.jsx
@@ -281,35 +281,6 @@ class ClassifierContainer extends React.Component {
               <span>Shortcuts</span>
             </button>
 
-            <img className="divider" role="presentation" src={Divider} />
-
-            <div>Currently working in <b>{currentMode}</b> mode</div>
-
-            <button
-              className="flat-button block"
-              onClick={()=>{
-                const confirmed = confirm('WARNING: You will lose all current progress (including saved work) if you switch modes. Is this OK?');
-                if (confirmed) {
-                  //If the use chooses to switch modes, remove ALL saved progress to prevent confusion.
-                  if (this.props.user) {
-                    const id = localStorage.getItem(`${this.props.user.id}.manual_save_classificationID`);
-                    localStorage.removeItem(`${this.props.user.id}.manual_save_classificationID`);
-                    localStorage.removeItem(`${this.props.user.id}.manual_save_workflowID`);
-                    localStorage.removeItem(`${this.props.user.id}.manual_save_variant`);
-                  }
-                  this.props.dispatch(clearEmergencySave());
-                  location.reload();
-                }
-              }}
-            >
-              <span className="classifier-toolbar__icon">
-                <i className="fa fa-arrows-h" />
-              </span>
-              <span>Switch to {toggleMode}</span>
-            </button>
-
-            <div>Warning: switching modes will reset all your current work.</div>
-
           </div>
         </section>
 

--- a/src/ducks/splits.js
+++ b/src/ducks/splits.js
@@ -8,7 +8,7 @@ const VARIANT_TYPES = {
 };
 
 const initialState = {
-  variant: VARIANT_TYPES.INDIVIDUAL,
+  variant: VARIANT_TYPES.COLLABORATIVE,
   data: null,
   id: null,
 };


### PR DESCRIPTION
Do not merge until we get the green light from the BPL team that the field guide has been updated and new subjects added.

This PR removes workflow selection from the classifier. I _think_ all our bases are covered here; however, with all the code to check for variants, it would be good to have a sharp eye on this. In a nutshell, changes here:

- Set default variant to `collaborative`
- Remove workflow selection section

Most of the code referencing variants and independent mode has been left in should we choose to revert back to that variant at some point.