### PR TITLE
Improve Caesar Error Handling

### DIFF
--- a/src/components/AnnotationsPane.jsx
+++ b/src/components/AnnotationsPane.jsx
@@ -135,7 +135,9 @@ class AnnotationsPane extends React.Component {
   }
 
   renderPreviousAnnotations() {
-    return this.renderAnnotations(this.props.previousAnnotations, true);
+    if (this.props.subjectId === this.props.previousAnnotationSubjectId) {
+      return this.renderAnnotations(this.props.previousAnnotations, true);
+    }
   }
 
   determineGreenLine(annotation, index) {
@@ -307,12 +309,14 @@ AnnotationsPane.propTypes = {
   rotation: PropTypes.number,
   getPointerXY: PropTypes.func,
   mouseInViewer: PropTypes.bool,
+  previousAnnotationSubjectId: PropTypes.string,
   previousAnnotations: PropTypes.arrayOf(PropTypes.object),
   selectedAnnotation: PropTypes.shape({
     previousAnnotation: PropTypes.bool,
   }),
   selectedAnnotationIndex: PropTypes.number,
   shownMarks: PropTypes.number,
+  subjectId: PropTypes.string,
   variant: PropTypes.string,
 };
 
@@ -329,11 +333,13 @@ AnnotationsPane.defaultProps = {
   annotations: [],
   rotation: 0,
   previousAnnotations: [],
+  previousAnnotationSubjectId: null,
   selectedAnnotation: {
     previousAnnotation: false,
   },
   selectedAnnotationIndex: 0,
   shownMarks: 0,
+  subjectId: null,
   variant: VARIANT_TYPES.INDIVIDUAL,
 };
 
@@ -341,9 +347,11 @@ const mapStateToProps = (state) => {
   return {
     frame: state.subjectViewer.frame,
     rotation: state.subjectViewer.rotation,
+    previousAnnotationSubjectId: state.previousAnnotations.subjectId,
     selectedAnnotation: state.annotations.selectedAnnotation,
     selectedAnnotationIndex: state.annotations.selectedAnnotationIndex,
     shownMarks: state.subjectViewer.shownMarks,
+    subjectId: state.subject.id,
     variant: state.splits.variant,
   };
 };

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -51,21 +51,18 @@ class App extends React.Component {
 
     return oauth.checkBearerToken()
       .then((token) => {
-        //If the App thinks you're logged in, but the token says otherwise, deploy emergency measures.
+        // If the App thinks you're logged in, but the token says otherwise, deploy emergency measures.
         if (props.initialised && props.user && !token) {
           this.props.dispatch(emergencySaveWorkInProgress());
           this.props.dispatch(toggleDialog(<DialogOfFailure />, false, true));
           return Promise.reject(new Error('User is supposed to be logged in, but token has expired.'));
-          //The intent is that if the user is supposed to be logged in but
-          //isn't, the whole request (that comes after .beforeEveryRequest)
-          //should not continue.
+          // The intent is that if the user is supposed to be logged in but
+          // isn't, the whole request (that comes after .beforeEveryRequest)
+          // should not continue.
         }
         return;
-      })
-      .catch((err) => {
-        console.error('Bearer Token Fetch Failed: ', err);
       });
-      //Note: do NOT add a catch() here, or else Promise.reject() above won't stop the API request.
+    // Note: do NOT add a catch() here, or else Promise.reject() above won't stop the API request.
   }
 
   getChildContext() {

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -36,7 +36,7 @@ class App extends React.Component {
     if (!props.initialised) {  //NOTE: This should almost always trigger, since App.constructor() triggers exactly once, on the website loading, when all initial values are at their default.
       props.dispatch(checkLoginUser());
     }
-    
+
     //SPECIAL: users on ASM tend to stay in a single session for WAY longer
     //than a standard Zooniverse CFE user, so we're encountering issues where
     //their login tokens timeout in the middle of classifying a document.
@@ -45,22 +45,25 @@ class App extends React.Component {
     //actions if necessary.
     apiClient.beforeEveryRequest = this.checkIfLoggedInUserIsStillLoggedIn.bind(this);
   }
-  
+
   checkIfLoggedInUserIsStillLoggedIn() {
     const props = this.props;
-    
+
     return oauth.checkBearerToken()
       .then((token) => {
         //If the App thinks you're logged in, but the token says otherwise, deploy emergency measures.
-        if (props.initialised && props.user && !token) {          
+        if (props.initialised && props.user && !token) {
           this.props.dispatch(emergencySaveWorkInProgress());
           this.props.dispatch(toggleDialog(<DialogOfFailure />, false, true));
           return Promise.reject(new Error('User is supposed to be logged in, but token has expired.'));
           //The intent is that if the user is supposed to be logged in but
           //isn't, the whole request (that comes after .beforeEveryRequest)
           //should not continue.
-        }      
+        }
         return;
+      })
+      .catch((err) => {
+        console.error('Bearer Token Fetch Failed: ', err);
       });
       //Note: do NOT add a catch() here, or else Promise.reject() above won't stop the API request.
   }

--- a/src/components/ClassificationPrompt.jsx
+++ b/src/components/ClassificationPrompt.jsx
@@ -19,12 +19,15 @@ class ClassificationPrompt extends React.Component {
     const classification_id = localStorage.getItem(`${this.props.user.id}.manual_save_classificationID`);
     const workflow_id = localStorage.getItem(`${this.props.user.id}.manual_save_workflowID`);
     const variant = localStorage.getItem(`${this.props.user.id}.manual_save_variant`);
-    
+
     this.props.dispatch(fetchWorkflow(workflow_id)).then(() => {
       this.props.dispatch(retrieveClassification(classification_id));
       this.props.dispatch(setVariant(variant));
-    });
-    
+    })
+      .catch((err) => {
+        console.error('Workflow Fetch Failed: ', err);
+      });
+
     this.props.onClose && this.props.onClose(e);
   }
 
@@ -35,7 +38,7 @@ class ClassificationPrompt extends React.Component {
     localStorage.removeItem(`${this.props.user.id}.manual_save_variant`);
 
     this.props.onClose && this.props.onClose(e);
-    
+
     return apiClient.type('classifications/incomplete').get({ id })
       .then(([classification]) => {
         classification.delete();

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -63,6 +63,9 @@ class Home extends React.Component {
           apiClient.type('subjects').get(newestSubjects)
             .then((subjectsOfNote) => {
               this.setState({ subjectsOfNote });
+            })
+            .catch((err) => {
+              console.error('Talk Subject Fetch Failed: ', err);
             });
         }
       })

--- a/src/components/SelectedAnnotation.jsx
+++ b/src/components/SelectedAnnotation.jsx
@@ -295,6 +295,7 @@ class SelectedAnnotation extends React.Component {
     // Previous (Aggregated) Annotation, or the user is creating/editing their
     // own.
     if (this.props.annotation.previousAnnotation) {
+      if (this.inputText && !this.inputText.value) return null;
       this.props.dispatch(collaborateWithAnnotation(this.props.annotation, this.state.annotationText));
       this.props.dispatch(updatePreviousAnnotation(this.props.selectedAnnotationIndex));
     } else {

--- a/src/containers/ClassifierContainer.jsx
+++ b/src/containers/ClassifierContainer.jsx
@@ -81,7 +81,10 @@ class ClassifierContainer extends React.Component {
     //----------------------------------------------------------------
     dispatch(fetchWorkflow(config.zooniverseLinks.collabWorkflowId)).then(() => {
       dispatch(fetchSubject());
-    });
+    })
+      .catch((err) => {
+        console.error('Workflow Fetch Failed: ', err);
+      });
     //----------------------------------------------------------------
 
     //Saved Progress Check

--- a/src/containers/CollectionsContainer.jsx
+++ b/src/containers/CollectionsContainer.jsx
@@ -21,11 +21,11 @@ class CollectionContainer extends React.Component {
     if (this.props.selectedCollections.length) {
       this.props.selectedCollections.forEach((item) => {
         item.collection.addLink('subjects', [this.props.currentSubject.id])
-        .then(() => { this.props.closePopup(); })
-        .catch((e) => {
-          this.setState({ error: e.toString() })
-        })
-      })
+          .then(() => { this.props.closePopup(); })
+          .catch((e) => {
+            this.setState({ error: e.toString() });
+          });
+      });
     }
   }
 
@@ -37,16 +37,16 @@ class CollectionContainer extends React.Component {
     const links = {
       project: this.props.project.id,
       subjects: [this.props.currentSubject.id]
-    }
-    const collection = { display_name, private: privateChecked, links }
+    };
+    const collection = { display_name, private: privateChecked, links };
 
     apiClient.type('collections').create(collection).save()
       .then(() => {
         this.props.closePopup();
       })
       .catch((e) => {
-        this.setState({ error: e.toString() })
-      })
+        this.setState({ error: e.toString() });
+      });
   }
 
   searchCollections(value) {
@@ -55,9 +55,9 @@ class CollectionContainer extends React.Component {
       page_size: 20,
       favorite: false,
       current_user_roles: 'owner, collaborator, contributor',
-    }
+    };
     if (value !== '') {
-      query.search = `${value}`
+      query.search = `${value}`;
     }
     return apiClient.type('collections').get(query).then((collections) => {
       options = collections.map((collection) => {
@@ -65,13 +65,13 @@ class CollectionContainer extends React.Component {
           value: collection.id,
           label: collection.display_name,
           collection
-        }
-      })
-      return { options }
+        };
+      });
+      return { options };
     })
-    .catch((e) => {
-      this.setState({ error: e.toString() })
-    })
+      .catch((e) => {
+        this.setState({ error: e.toString() });
+      });
   }
 
   render() {

--- a/src/ducks/emergency-save.js
+++ b/src/ducks/emergency-save.js
@@ -39,7 +39,7 @@ const emergencySaveWorkInProgress = () => {
     const annotations = getState().annotations.annotations;
     const variant = getState().splits.variant;
 
-    if (subjectId !== null) {      
+    if (subjectId !== null) {
       const userId = (getState().login.user) ? getState().login.user.id : ANONYMOUS_USER_ID;
       localStorage.setItem(`${userId}.${SUBJECT_ID_KEY}`, subjectId);
       localStorage.setItem(`${userId}.${WORKFLOW_ID_KEY}`, workflowId);
@@ -63,15 +63,18 @@ const emergencyLoadWorkInProgress = () => {
       const variant = localStorage.getItem(`${userId}.${VARIANT_KEY}`);
 
       dispatch(fetchWorkflow(workflowId)).then(() => {
-        dispatch(fetchSavedSubject(subjectId))        
-        .then(() => {
-          prepareForNewSubject(dispatch, null);
-          dispatch(setAnnotations(annotations));  //Note: be sure to set Annotations AFTER prepareForNewSubject().
-          dispatch(setVariant(variant));
-          dispatch(clearEmergencySave());
-        });
+        dispatch(fetchSavedSubject(subjectId))
+          .then(() => {
+            prepareForNewSubject(dispatch, null);
+            dispatch(setAnnotations(annotations));  //Note: be sure to set Annotations AFTER prepareForNewSubject().
+            dispatch(setVariant(variant));
+            dispatch(clearEmergencySave());
+          })
+          .catch((err) => {
+            console.error('Emergency Load Failed: ', err);
+          });
       });
-      
+
       console.info('emergencyLoadWorkInProgress()');
       Rollbar && Rollbar.info &&
       Rollbar.info('emergencyLoadWorkInProgress()');

--- a/src/ducks/field-guide.js
+++ b/src/ducks/field-guide.js
@@ -44,21 +44,23 @@ const fieldGuideReducer = (state = initialState, action) => {
 };
 
 const fetchGuide = () => {
-  return (dispatch, getState) => {
-
+  return (dispatch) => {
     dispatch({
       type: FETCH_GUIDE,
     });
 
     apiClient.type('field_guides').get({ project_id: `${config.zooniverseLinks.projectId}` }).then(([guide]) => {
-      let icons = {};
+      const icons = {};
 
       if (guide) {
         guide.get('attached_images', { page_size: 100 }).then((images) => {
           images.map((image) => {
             icons[image.id] = image;
           });
-        });
+        })
+          .catch((err) => {
+            console.error('Attached Image Retieval Failed: ', err);
+          });
       }
 
       dispatch({
@@ -67,10 +69,10 @@ const fetchGuide = () => {
         guide
       });
     })
-    .catch((err) => {
-      console.error('ducks/field-guide.js fetchGuide() error: ', err);
-      dispatch({ type: FETCH_GUIDE_ERROR });
-    });
+      .catch((err) => {
+        console.error('ducks/field-guide.js fetchGuide() error: ', err);
+        dispatch({ type: FETCH_GUIDE_ERROR });
+      });
   };
 };
 

--- a/src/ducks/login.js
+++ b/src/ducks/login.js
@@ -46,6 +46,9 @@ const logoutFromPanoptes = () => {
     oauth.signOut()
       .then((user) => {
         dispatch(setLoginUser(user));
+      })
+      .catch((err) => {
+        console.error('User Login Error: ', err);
       });
   };
 };

--- a/src/ducks/previousAnnotations.js
+++ b/src/ducks/previousAnnotations.js
@@ -21,6 +21,7 @@ const initialState = {
   data: null,
   marks: [],
   selectedPreviousAnnotation: null,
+  subjectId: null,
   status: PREVIOUS_ANNOTATION_STATUS.IDLE,
 };
 
@@ -31,6 +32,7 @@ const previousAnnotationsReducer = (state = initialState, action) => {
         data: null,
         marks: [],
         selectedPreviousAnnotation: null,
+        subjectId: null,
         status: PREVIOUS_ANNOTATION_STATUS.FETCHING,
       });
 
@@ -39,6 +41,7 @@ const previousAnnotationsReducer = (state = initialState, action) => {
         data: action.data,
         marks: action.marks,
         status: PREVIOUS_ANNOTATION_STATUS.READY,
+        subjectId: action.subjectId
       });
 
     case FETCH_ANNOTATIONS_ERROR:
@@ -111,7 +114,6 @@ const fetchPreviousAnnotations = (subject) => {
     dispatch({
       type: FETCH_ANNOTATIONS,
     });
-
     request(config.zooniverseLinks.caesarHost, query).then((data) => {
       const frame = getState().subjectViewer.frame;
       const reductions = data.workflow.subject_reductions;
@@ -121,6 +123,7 @@ const fetchPreviousAnnotations = (subject) => {
         type: FETCH_ANNOTATIONS_SUCCESS,
         data: data.workflow.subject_reductions,
         marks,
+        subjectId: subject.id
       });
     })
       .catch((err) => {

--- a/src/ducks/previousAnnotations.js
+++ b/src/ducks/previousAnnotations.js
@@ -54,7 +54,9 @@ const previousAnnotationsReducer = (state = initialState, action) => {
     case UPDATE_PREVIOUS_ANNOTATION:
       const marks = state.marks.slice();
       const updatedAnnotation = marks[action.index];
-      updatedAnnotation.hasCollaborated = true;
+      if (updatedAnnotation) {
+        updatedAnnotation.hasCollaborated = true;
+      }
 
       return Object.assign({}, state, {
         marks,

--- a/src/ducks/project.js
+++ b/src/ducks/project.js
@@ -110,11 +110,11 @@ const fetchProject = (id = config.zooniverseLinks.projectId) => {
         });
       })
       .catch((err) => {
-        //Step 3b: Tell the Redux store we screwed up.
+        // Step 3b: Tell the Redux store we screwed up.
         console.error('ducks/project.js fetchProject() error: ', err);
         Rollbar && Rollbar.error &&
         Rollbar.error('ducks/project.js fetchProject() error: ', err);
-        
+
         dispatch({ type: FETCH_PROJECT_ERROR });
       });
   };
@@ -160,6 +160,9 @@ const fetchPreferences = (user) => {
                 console.error('ducks/project.js fetchPreferences() error: ', err);
               });
           }
+        })
+        .catch((err) => {
+          console.error('Preferences Fetch Warning: ', err);
         });
     } else {
       Promise.resolve(apiClient.type('project_preferences').create({
@@ -171,7 +174,10 @@ const fetchPreferences = (user) => {
           type: FETCH_PREFERENCES,
           preferences,
         });
-      });
+      })
+        .catch((err) => {
+          console.error('Guest Preferences Failed to Save: ', err);
+        });
     }
   };
 };

--- a/src/ducks/subject.js
+++ b/src/ducks/subject.js
@@ -162,6 +162,9 @@ const toggleFavorite = () => {
           createFavorites(getState().project).then((collection) => addSubjectToCollection(collection, subject.id));
         }
       })
+        .catch((err) => {
+          console.error('Collection Fetch Warning: ', err);
+        });
     }
   }
 };

--- a/src/ducks/tutorial.js
+++ b/src/ducks/tutorial.js
@@ -42,8 +42,7 @@ const tutorialReducer = (state = initialState, action) => {
 };
 
 const fetchTutorial = (workflow) => {
-  return (dispatch, getState) => {
-
+  return (dispatch) => {
     dispatch({
       type: FETCH_TUTORIAL,
     });
@@ -52,12 +51,12 @@ const fetchTutorial = (workflow) => {
       dispatch({
         type: FETCH_TUTORIAL_SUCCESS,
         data: tutorial
-      })
+      });
     })
-    .catch((err) => {
-      console.error('ducks/tutorial.js fetchTutorial() error: ', err);
-      dispatch({ type: FETCH_TUTORIAL_ERROR });
-    });
+      .catch((err) => {
+        console.error('ducks/tutorial.js fetchTutorial() error: ', err);
+        dispatch({ type: FETCH_TUTORIAL_ERROR });
+      });
   };
 };
 

--- a/src/ducks/workflow.js
+++ b/src/ducks/workflow.js
@@ -60,7 +60,7 @@ const workflowReducer = (state = WORKFLOW_INITIAL_STATE, action) => {
         id: WORKFLOW_INITIAL_STATE.id,
         data: WORKFLOW_INITIAL_STATE.data,
       });
-      
+
     case FETCH_WORKFLOW:
       return Object.assign({}, state, {
         status: WORKFLOW_STATUS.FETCHING,
@@ -107,18 +107,18 @@ const fetchWorkflow = (id) => {
     });
 
     return apiClient.type('workflows').get(id)
-    .then((workflow) => {
-      dispatch({
-        type: FETCH_WORKFLOW_SUCCESS,
-        data: workflow,
+      .then((workflow) => {
+        dispatch({
+          type: FETCH_WORKFLOW_SUCCESS,
+          data: workflow,
+        });
+      })
+      .catch((err) => {
+        console.error('ducks/workflow.js fetchWorkflow() error: ', err);
+        dispatch({ type: FETCH_WORKFLOW_ERROR });
       });
-    })
-    .catch((err) => {
-      console.error('ducks/workflow.js fetchWorkflow() error: ', err);
-      dispatch({ type: FETCH_WORKFLOW_ERROR });
-    });
   };
-}
+};
 
 const setGoldStandard = () => {
   return (dispatch, getState) => {


### PR DESCRIPTION
Closes #284 

Users are reporting errors of seeing annotations from different subjects. This PR attempts to solve those issues by making several changes:

**Main changes:**
- Fixes a bug where users can submit a blank classification using keyboard shortcuts (ctrl + enter). Try selecting a previous annotation, keep the box blank, and hit the shortcut.
- Ensure subject id fetched from Caesar matches the displayed subject id.
- Fix error seen in Rollbar where user tries to update a non-existent annotation (probably from incorrectly shown lines of a previous annotation).
- Adds catches to all promises.

**Other changes:**
- Fixes various linter issues, mainly line indents

The main error received from Rollbar recently is an `unhandled rejection was null or undefined!` error stemming from [this call](https://github.com/zooniverse/anti-slavery-manuscripts/blob/master/src/components/App.jsx#L52) failing, which happens whenever a user's token expires. Take a look at the screenshot below, made after the addition of the catch in this PR. Both the `then` and `catch` are reached due to the `Promise.reject`. 

<img width="905" alt="screen shot 2019-02-13 at 8 41 15 am" src="https://user-images.githubusercontent.com/14099077/52724589-4366cb00-2f75-11e9-84e8-b7fe6493ef1d.png">


I could've added an exception to the Rollbar config to ignore unhandled rejections, but it seemed better practice to add catches.

**Note:** This will not necessarily _solve_ all errors received from Caesar, but it should help users experiencing annotations appearing from different subjects.