### PR TITLE
Update Polyfill and Add Promise

### DIFF
--- a/src/index.tpl.html
+++ b/src/index.tpl.html
@@ -36,6 +36,6 @@
     <div id="root"></div>
     <%= htmlWebpackPlugin.options.gtm %>
 
-    <script src="https://ft-polyfill-service.herokuapp.com/v2/polyfill.min.js?features=default,es6,Array.prototype.includes,Array.prototype.keys"></script>
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=default,es6,Promise,Array.prototype.includes,Array.prototype.keys"></script>
   </body>
 </html>


### PR DESCRIPTION
**Current Error**
A user on the [talk board](https://www.zooniverse.org/talk/13/923080?comment=1525480&page=1) was mentioning experiencing an infinite load on the site.

**tl;dr**
I updated the polyfill to fix the error. I'm _guessing_ this is why the user is experiencing issues, but it'd be worth double checking on an older version of IE.

**Condition in App.jsx**
An infinite load could only be caused by [this condition](https://github.com/zooniverse/anti-slavery-manuscripts/blob/master/src/components/App.jsx#L100) not being met on app load. This is the unlikely culprit, as Rollbar only mentions one instance, several months ago, of `Rollbar.error('ducks/project.js fetchProject() error: ', err);` ever being recorded.

Likewise, `initialized` should eventually return `true` since the OAuth package resolves accordingly without an api call [here](https://github.com/zooniverse/anti-slavery-manuscripts/blob/master/src/ducks/login.js#L32).

**Missing Polyfill**
Looking at Rollbar again, the `ReferenceError: 'Promise' is undefined` error occurs many times, only in IE. IE doesn't support `Promise` natively, which is why we use a polyfill. However, the polyfill service is currently faliing on the site `GET https://ft-polyfill-service.herokuapp.com/v2/polyfill.min.js?features=default,es6,Array.prototype.includes,Array.prototype.keys net::ERR_ABORTED 404 (Not Found)`. Because of this, I updated the polyfill url based on the [polyfill site](https://polyfill.io/v3/url-builder/).