### PR TITLE
Update ZRC to remove `this.updater.enqueueCallback is not a function` error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8988,6 +8988,11 @@
       "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM=",
       "dev": true
     },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+    },
     "lodash.map": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
@@ -11855,13 +11860,13 @@
       }
     },
     "react-swipe": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/react-swipe/-/react-swipe-5.1.1.tgz",
-      "integrity": "sha512-7o4rktmVVTQaZk5MoibL3tR9tA/5qLy8jlKLtMn7IcDl6nj7Vafb7OIuqExWoPNb/Xe1SLTnwEoaHICGKDCGew==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/react-swipe/-/react-swipe-6.0.4.tgz",
+      "integrity": "sha512-NIF+gVOqPpE8GyCg0ssFC+fPgeqCwNnvqFU/A8nDAOvoncW3KjSVFwgkYNnErHvpFZGmsVw4SLWK96n7+mnChg==",
       "requires": {
-        "object-assign": "^4.1.1",
+        "lodash.isequal": "^4.5.0",
         "prop-types": "^15.6.0",
-        "swipe-js-iso": "^2.0.4"
+        "swipe-js-iso": "^2.1.5"
       },
       "dependencies": {
         "loose-envify": {
@@ -17745,35 +17750,24 @@
       }
     },
     "zooniverse-react-components": {
-      "version": "github:zooniverse/Zooniverse-react-components#967fda93517c9fad853c298633e7555262215357",
-      "from": "github:zooniverse/Zooniverse-react-components#v0.7.3",
+      "version": "github:zooniverse/Zooniverse-react-components#8ad7543c11c8874500075fded96445cccda13819",
+      "from": "github:zooniverse/Zooniverse-react-components#v0.8.1",
       "requires": {
         "animated-scrollto": "^1.1.0",
         "data-uri-to-blob": "0.0.4",
         "grommet": "^1.8.2",
         "markdownz": "^7.6.5",
-        "modal-form": "^2.8.0",
+        "modal-form": "^2.9.0",
         "panoptes-client": "^2.12.2",
         "prop-types": "~15.5.10",
-        "react": "^15.6.1",
-        "react-dom": "^15.6.1",
-        "react-select": "^1.0.0-rc.5",
-        "react-swipe": "^5.0.8"
+        "react-select": "1.0.0-rc.10",
+        "react-swipe": "^6.0.4"
       },
       "dependencies": {
-        "json-api-client": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/json-api-client/-/json-api-client-4.0.2.tgz",
-          "integrity": "sha512-Hxki1EGD8J3hdvAWo6cQy5aCcVH/VT6hzrYF9VTuy6lkvZaXPfodQR5p5Vh2Zc/SUl/yvcp2l7RHPiqUgpzQmA==",
-          "requires": {
-            "normalizeurl": "~0.1.3",
-            "superagent": "^3.8.3"
-          }
-        },
         "markdownz": {
-          "version": "7.7.0",
-          "resolved": "https://registry.npmjs.org/markdownz/-/markdownz-7.7.0.tgz",
-          "integrity": "sha512-p14iPNDsZnvx59uji3eB8lJJRq0ph2ImaBgssgqKInQH1PJPxYoRoDcZwD7fjSa6yHa9KV0PfMRbklrsMHlRFQ==",
+          "version": "7.7.1",
+          "resolved": "https://registry.npmjs.org/markdownz/-/markdownz-7.7.1.tgz",
+          "integrity": "sha512-hrnNr1CGKKPE9Pqpv/2hrwjd6EGfvigUSr0SiLnRZj1oyJoio7CHT7CwA2iWmrcq2kYBG616kZEguYcO0x7C9Q==",
           "requires": {
             "markdown-it": "~8.4.1",
             "markdown-it-anchor": "~5.0.2",
@@ -17789,37 +17783,14 @@
             "twemoji": "~1.4.1"
           }
         },
-        "panoptes-client": {
-          "version": "2.12.3",
-          "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-2.12.3.tgz",
-          "integrity": "sha512-iw0+2CkYDjyWzzWk//KfJQAECqsMum77L1AQcYd5a3KEEWdj/AERQF/RuqW/je2zzFWL/zTE5MvImUAZShJFCA==",
+        "react-select": {
+          "version": "1.0.0-rc.10",
+          "resolved": "https://registry.npmjs.org/react-select/-/react-select-1.0.0-rc.10.tgz",
+          "integrity": "sha1-8Tc0YlD5JVyXn7+iGGCJmSh3I1A=",
           "requires": {
-            "json-api-client": "^4.0.2",
-            "local-storage": "^1.4.2",
-            "sugar-client": "^1.0.1"
-          }
-        },
-        "react": {
-          "version": "15.6.2",
-          "resolved": "https://registry.npmjs.org/react/-/react-15.6.2.tgz",
-          "integrity": "sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=",
-          "requires": {
-            "create-react-class": "^15.6.0",
-            "fbjs": "^0.8.9",
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.0",
-            "prop-types": "^15.5.10"
-          }
-        },
-        "react-dom": {
-          "version": "15.6.2",
-          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.2.tgz",
-          "integrity": "sha1-Qc+t9pO3V/rycIRDodH9WgK+9zA=",
-          "requires": {
-            "fbjs": "^0.8.9",
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.0",
-            "prop-types": "^15.5.10"
+            "classnames": "^2.2.4",
+            "prop-types": "^15.5.8",
+            "react-input-autosize": "^2.0.1"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "redux-logger": "~2.7.4",
     "redux-thunk": "~2.1.0",
     "zoo-grommet": "~0.3.0",
-    "zooniverse-react-components": "github:zooniverse/Zooniverse-react-components#v0.7.3"
+    "zooniverse-react-components": "github:zooniverse/Zooniverse-react-components#v0.8.1"
   },
   "devDependencies": {
     "@babel/cli": "~7.0.0",


### PR DESCRIPTION
## PR Overview

This PR updates the Zooniverse React Components package to the latest version, which uses React 16, matching the rest of this project. As a result, this removes the `this.updater.enqueueCallback is not a function` error that's popping up in the consoles.

Merging, go.