### PR TITLE
Create Staging Script

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test-travis": "true",
     "eslint": "eslint .",
     "build": "BABEL_ENV=production check-engines && check-dependencies && webpack --config webpack.production.config.js -p",
-    "_stage": "BABEL_ENV=staging check-engines && check-dependencies && webpack --config webpack.config.js -p",
+    "_stage": "BABEL_ENV=staging check-engines && check-dependencies && webpack --config webpack.config.js",
     "deploy-production": "NODE_ENV=production npm run build && publisssh dist zooniverse-static/www.antislaverymanuscripts.org",
     "deploy-staging": "NODE_ENV=staging npm run _stage && publisssh dist zooniverse-static/preview.zooniverse.org/antislaverymanuscripts"
   },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "test-travis": "true",
     "eslint": "eslint .",
     "build": "BABEL_ENV=production check-engines && check-dependencies && webpack --config webpack.production.config.js -p",
-    "deploy-production": "NODE_ENV=production npm run build && publisssh dist zooniverse-static/www.antislaverymanuscripts.org"
+    "_stage": "BABEL_ENV=staging check-engines && check-dependencies && webpack --config webpack.config.js -p",
+    "deploy-production": "NODE_ENV=production npm run build && publisssh dist zooniverse-static/www.antislaverymanuscripts.org",
+    "deploy-staging": "NODE_ENV=staging npm run _stage && publisssh dist zooniverse-static/preview.zooniverse.org/antislaverymanuscripts"
   },
   "engines": {
     "node": "^10.15.3",


### PR DESCRIPTION
This PR creates a staging script so we can get a staging version deployed. This will make it easier for other users to log in and submit staging classifications through the CFE.

**Use case:**
We need to test out the ALICE pipeline, but we'd like to try it with a fresh subject set. I've created a subject set on ASM staging for this purpose, but I'd like multiple people to submit classifications. Rather than get multiple non-devs set up with the local app, etc. etc. I think it'd be easier to get a staging site deployed, finally.