### PR TITLE
Fix Typo in og Title

### DIFF
--- a/src/index.tpl.html
+++ b/src/index.tpl.html
@@ -18,7 +18,7 @@
 
     <meta name="description" content="Anti-Slavery Manuscripts invites volunteers to transcribe documents from the American abolitionist movement, working together with the Zooniverse community and the Boston Public Library.">
     <meta property="og:url" content="https://www.antislaverymanuscripts.org/">
-    <meta property="og:title" content="Anti-Slavery Manuscript">
+    <meta property="og:title" content="Anti-Slavery Manuscripts">
     <meta property="og:description" content="Anti-Slavery Manuscripts invites volunteers to transcribe documents from the American abolitionist movement, working together with the Zooniverse community and the Boston Public Library.">
     <meta property="og:image" content="https://dailyzooniverse.files.wordpress.com/2018/01/bpl-handout-012218.jpg">
     <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
og:title should read "Anti-Slavery Manuscripts," instead of "Anti-Slavery Manuscript"