### PR TITLE
Create Maintenance Message

### DIFF
--- a/src/index.tpl.html
+++ b/src/index.tpl.html
@@ -42,8 +42,9 @@
   <body style="text-align: center; font-family: 'Playfair Display', serif">
     <h1>Under maintenance</h1>
     <p style="margin-bottom: 0">Anti-Slavery Manuscripts is currently under maintenance</p>
-    <p>We'll be up again in an hour.</p>
-    <p>We apologize for any inconvenience.</p>
+    <p>We'll be up again in an soon.</p>
+    <p>You can keep up-to-date with the status of the Zooniverse platform at all times via our page at <a href="https://status.zooniverse.org">status.zooniverse.org</a>, and via our <a href="https://twitter.com/the_zooniverse">Twitter account</a>.</p>
+
     <%= htmlWebpackPlugin.options.gtm %>
 
     <script src="https://polyfill.io/v3/polyfill.min.js?features=default,es6,Promise,Array.prototype.includes,Array.prototype.keys"></script>

--- a/src/index.tpl.html
+++ b/src/index.tpl.html
@@ -17,7 +17,7 @@
     <!-- End Google Analytics -->
 
     <meta name="description" content="Anti-Slavery Manuscripts invites volunteers to transcribe documents from the American abolitionist movement, working together with the Zooniverse community and the Boston Public Library.">
-    
+
     <meta property="og:url" content="https://www.antislaverymanuscripts.org/">
     <meta property="og:title" content="Anti-Slavery Manuscripts">
     <meta property="og:description" content="Anti-Slavery Manuscripts invites volunteers to transcribe documents from the American abolitionist movement, working together with the Zooniverse community and the Boston Public Library.">
@@ -26,7 +26,7 @@
     <meta property="og:image:width" content="825">
     <meta property="og:image:height" content="637">
     <meta property="og:image:alt" content="Text logo of Anti-Slavery Manuscripts, with the sub-header: presented by the Boston Public Library and Zooniverse">
-    
+
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@the_zooniverse">
     <meta name="twitter:creator" content="@the_zooniverse">
@@ -34,13 +34,16 @@
     <meta name="twitter:description" content="Anti-Slavery Manuscripts invites volunteers to transcribe documents from the American abolitionist movement, working together with the Zooniverse community and the Boston Public Library.">
     <meta name="twitter:image" content="https://dailyzooniverse.files.wordpress.com/2018/01/bpl-handout-012218.jpg">
     <meta name="twitter:image:alt" content="Text logo of Anti-Slavery Manuscripts, with the sub-header: presented by the Boston Public Library and Zooniverse">
-    
+
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
     <link href="https://fonts.googleapis.com/css?family=Cormorant|Roboto|Oswald:300|Karla:700|Playfair+Display:400,400i,700" rel="stylesheet">
   </head>
-  <body>
-    <div id="root"></div>
+  <body style="text-align: center; font-family: 'Playfair Display', serif">
+    <h1>Under maintenance</h1>
+    <p style="margin-bottom: 0">Anti-Slavery Manuscripts is currently under maintenance</p>
+    <p>We'll be up again in an hour.</p>
+    <p>We apologize for any inconvenience.</p>
     <%= htmlWebpackPlugin.options.gtm %>
 
     <script src="https://polyfill.io/v3/polyfill.min.js?features=default,es6,Promise,Array.prototype.includes,Array.prototype.keys"></script>


### PR DESCRIPTION
Creates a quick maintenance message on the home screen based on a [PR](https://github.com/zooniverse/Panoptes-Front-End/pull/5770) by @shaunanoordin.

<img width="750" alt="Screen Shot 2020-07-21 at 9 05 15 AM" src="https://user-images.githubusercontent.com/14099077/88065278-04598380-cb32-11ea-9d72-96fc466dc429.png">
