### PR TITLE
Remove Annotate Key Shortcut

### DIFF
--- a/src/components/KeyboardShortcuts.jsx
+++ b/src/components/KeyboardShortcuts.jsx
@@ -14,10 +14,6 @@ const KeyboardShortcuts = () => {
             <td>Toggle Previous Marks</td>
           </tr>
           <tr>
-            <td>a</td>
-            <td>Toggle Navigate and Transcribe</td>
-          </tr>
-          <tr>
             <th>When Transcribing</th>
           </tr>
           <tr>

--- a/src/containers/ClassifierContainer.jsx
+++ b/src/containers/ClassifierContainer.jsx
@@ -347,13 +347,13 @@ class ClassifierContainer extends React.Component {
 
   handleKeyUp(e) {
     if (this.props.selectedAnnotation === null) {
-      if (Utility.getKeyCode(e) === KEY_CODES.A) {
-        if (this.props.viewerState === SUBJECTVIEWER_STATE.NAVIGATING && !this.props.selectedAnnotation) {
-          this.props.dispatch(setViewerState(SUBJECTVIEWER_STATE.ANNOTATING));
-        } else {
-          this.props.dispatch(setViewerState(SUBJECTVIEWER_STATE.NAVIGATING));
-        }
-      }
+      // if (Utility.getKeyCode(e) === KEY_CODES.A) {
+      //   if (this.props.viewerState === SUBJECTVIEWER_STATE.NAVIGATING && !this.props.selectedAnnotation) {
+      //     this.props.dispatch(setViewerState(SUBJECTVIEWER_STATE.ANNOTATING));
+      //   } else {
+      //     this.props.dispatch(setViewerState(SUBJECTVIEWER_STATE.NAVIGATING));
+      //   }
+      // }
       if (Utility.getKeyCode(e) === KEY_CODES.M) {
         this.togglePreviousMarks();
       }


### PR DESCRIPTION
Forgot to remove the "annotate" quick-key when merging #316. This remove the quick key functionality as well as the mention of it in the Shortcuts modal.