### PR TITLE
Remove the public path configuration to work on azure

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,8 +24,7 @@ module.exports = {
   ],
   output: {
     path: path.join(__dirname, '/dist/'),
-    filename: '[name].js',
-    publicPath: '/',
+    filename: '[name].js'
   },
   plugins: [
     new webpack.DefinePlugin({

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -29,7 +29,6 @@ module.exports = {
     }
   },
   output: {
-    publicPath: '/',
     path: path.join(__dirname, '/dist/'),
     filename: '[name]-[chunkhash].min.js',
     chunkFilename: '[name]-[chunkhash].js',
@@ -69,7 +68,7 @@ module.exports = {
       use: [{
         loader: MiniSccExtractPlugin.loader,
       }, {
-        loader: 'css-loader',
+        loader: 'css-loader'
       }, {
         loader: 'stylus-loader',
         options: {


### PR DESCRIPTION
Removes public path configuration from the webpack output because folders are fake on azure. 