### PR TITLE
[Security] Update markdownz and panoptes-client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "graphql-request": "~1.3.4",
         "history": "~4.6.1",
         "markdownz": "~7.8.1",
-        "panoptes-client": "^3.0.0-rc.0",
+        "panoptes-client": "^3.3.4",
         "prop-types": "^15.5.10",
         "react": "^16.8.6",
         "react-dom": "^16.8.6",
@@ -10457,9 +10457,9 @@
       }
     },
     "node_modules/json-api-client": {
-      "version": "5.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/json-api-client/-/json-api-client-5.0.0-rc.0.tgz",
-      "integrity": "sha512-xnGt9yfU9s3v7Lll3gEVY1xJd/auR0AaLmph2KBhK9CclrSxfpoP9rvMX5Qh1A7CBjIGai0JpJm8bjTWf9o2Yw==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/json-api-client/-/json-api-client-5.0.3.tgz",
+      "integrity": "sha512-vMk6rmJKi4QiWSzxhqt5xQwGjnXLPh4upXibZAt3RZOK1TisI06no9n4/UjsyB+8v689LnySgudooJoVhg2hdQ==",
       "dependencies": {
         "normalizeurl": "~0.1.3",
         "superagent": "^3.8.3"
@@ -12750,13 +12750,13 @@
       "dev": true
     },
     "node_modules/panoptes-client": {
-      "version": "3.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-3.0.0-rc.0.tgz",
-      "integrity": "sha512-eWKvvMXzIVdt8YMwF6PdG4K7dSHlP8LpSI0TJ9C3IME2U96YDEBsKiZKUaP+5IzJyv21Mj9sXlmVRL0KYtNH3Q==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-3.3.4.tgz",
+      "integrity": "sha512-37ZxdLBUkTBmo/eoCyVYijvsnvnCXt9lzKfwbVKFmYlMCSujlDBmHIb4lKSiaKd3Jg3r19NqGiqTQF1ZO4U5pg==",
       "dependencies": {
-        "json-api-client": "~5.0.0-rc.0",
+        "json-api-client": "~5.0.0",
         "local-storage": "^1.4.2",
-        "sugar-client": "^1.0.1"
+        "sugar-client": "^1.1.0"
       }
     },
     "node_modules/parallel-transform": {
@@ -16421,9 +16421,12 @@
       }
     },
     "node_modules/sugar-client": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sugar-client/-/sugar-client-1.0.1.tgz",
-      "integrity": "sha1-zRhz+/Kn2smm8prKHq2hr3UTz58="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/sugar-client/-/sugar-client-1.1.0.tgz",
+      "integrity": "sha512-/1fgJcTUQPUw4hrT/AXpI4iVdsoXIIgVrbj3mPGMJWD00JHtWna5KmKyeoqNKSCO672UK+5Cc9/B53UfzthbwA==",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/superagent": {
       "version": "3.8.3",
@@ -28693,9 +28696,9 @@
       "dev": true
     },
     "json-api-client": {
-      "version": "5.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/json-api-client/-/json-api-client-5.0.0-rc.0.tgz",
-      "integrity": "sha512-xnGt9yfU9s3v7Lll3gEVY1xJd/auR0AaLmph2KBhK9CclrSxfpoP9rvMX5Qh1A7CBjIGai0JpJm8bjTWf9o2Yw==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/json-api-client/-/json-api-client-5.0.3.tgz",
+      "integrity": "sha512-vMk6rmJKi4QiWSzxhqt5xQwGjnXLPh4upXibZAt3RZOK1TisI06no9n4/UjsyB+8v689LnySgudooJoVhg2hdQ==",
       "requires": {
         "normalizeurl": "~0.1.3",
         "superagent": "^3.8.3"
@@ -30595,13 +30598,13 @@
       "dev": true
     },
     "panoptes-client": {
-      "version": "3.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-3.0.0-rc.0.tgz",
-      "integrity": "sha512-eWKvvMXzIVdt8YMwF6PdG4K7dSHlP8LpSI0TJ9C3IME2U96YDEBsKiZKUaP+5IzJyv21Mj9sXlmVRL0KYtNH3Q==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-3.3.4.tgz",
+      "integrity": "sha512-37ZxdLBUkTBmo/eoCyVYijvsnvnCXt9lzKfwbVKFmYlMCSujlDBmHIb4lKSiaKd3Jg3r19NqGiqTQF1ZO4U5pg==",
       "requires": {
-        "json-api-client": "~5.0.0-rc.0",
+        "json-api-client": "~5.0.0",
         "local-storage": "^1.4.2",
-        "sugar-client": "^1.0.1"
+        "sugar-client": "^1.1.0"
       }
     },
     "parallel-transform": {
@@ -33638,9 +33641,9 @@
       }
     },
     "sugar-client": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sugar-client/-/sugar-client-1.0.1.tgz",
-      "integrity": "sha1-zRhz+/Kn2smm8prKHq2hr3UTz58="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/sugar-client/-/sugar-client-1.1.0.tgz",
+      "integrity": "sha512-/1fgJcTUQPUw4hrT/AXpI4iVdsoXIIgVrbj3mPGMJWD00JHtWna5KmKyeoqNKSCO672UK+5Cc9/B53UfzthbwA=="
     },
     "superagent": {
       "version": "3.8.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "counterpart": "~0.18.1",
         "graphql-request": "~1.3.4",
         "history": "~4.6.1",
-        "markdownz": "~7.6.3",
+        "markdownz": "~7.8.1",
         "panoptes-client": "^3.0.0-rc.0",
         "prop-types": "^15.5.10",
         "react": "^16.8.6",
@@ -79,7 +79,7 @@
       },
       "engines": {
         "node": ">=14",
-        "npm": ">=6"
+        "npm": ">=7"
       }
     },
     "node_modules/@babel/cli": {
@@ -1507,6 +1507,28 @@
         "@types/minimatch": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
+      "integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==",
+      "peer": true
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "12.2.3",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
+      "integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
+      "peer": true,
+      "dependencies": {
+        "@types/linkify-it": "*",
+        "@types/mdurl": "*"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
+      "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
+      "peer": true
     },
     "node_modules/@types/minimatch": {
       "version": "3.0.3",
@@ -7230,6 +7252,27 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true
     },
+    "node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/fs-extra/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "node_modules/fs-readdir-recursive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
@@ -8206,13 +8249,9 @@
       }
     },
     "node_modules/graceful-fs": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
-      }
+      "version": "4.2.9",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
+      "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ=="
     },
     "node_modules/graceful-readlink": {
       "version": "1.0.1",
@@ -10471,6 +10510,17 @@
         "json5": "lib/cli.js"
       }
     },
+    "node_modules/jsonfile": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-5.0.0.tgz",
+      "integrity": "sha512-NQRZ5CRo74MhMMC3/3r5g2k4fjodJ/wh8MxjFbCViWKFjxrnudWSY5vomh+23ZaXzAS7J3fBZIR2dV6WbmfM0w==",
+      "dependencies": {
+        "universalify": "^0.1.2"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz",
@@ -10867,27 +10917,28 @@
       }
     },
     "node_modules/markdown-it-anchor": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.0.2.tgz",
-      "integrity": "sha512-AFM/woBI8QDJMS/9+MmsBMT5/AR+ImfOsunQZTZhzcTmna3rIzAzbOh5E0l6mlFM/i9666BpUtkqQ9bS7WApCg==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.4.1.tgz",
+      "integrity": "sha512-sLODeRetZ/61KkKLJElaU3NuU2z7MhXf12Ml1WJMSdwpngeofneCRF+JBbat8HiSqhniOMuTemXMrsI7hA6XyA==",
       "peerDependencies": {
-        "markdown-it": "^8.4.1"
+        "@types/markdown-it": "*",
+        "markdown-it": "*"
       }
     },
     "node_modules/markdown-it-container": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-it-container/-/markdown-it-container-2.0.0.tgz",
-      "integrity": "sha1-ABm0P9Au7+zi8ZYKKJX7qBpARpU="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-container/-/markdown-it-container-3.0.0.tgz",
+      "integrity": "sha512-y6oKTq4BB9OQuY/KLfk/O3ysFhB3IMYoIWhGJEidXt1NQFocFK2sA2t0NYZAMyMShAGL6x5OPIbrmXPIqaN9rw=="
     },
     "node_modules/markdown-it-emoji": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/markdown-it-emoji/-/markdown-it-emoji-1.2.0.tgz",
-      "integrity": "sha1-VUqXdn1mI5NuHI1DBn8OQbeWqsM="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-emoji/-/markdown-it-emoji-2.0.0.tgz",
+      "integrity": "sha512-39j7/9vP/CPCKbEI44oV8yoPJTpvfeReTn/COgRhSpNrjWF3PfP/JUxxB0hxV6ynOY8KH8Y8aX9NMDdo6z+6YQ=="
     },
     "node_modules/markdown-it-footnote": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/markdown-it-footnote/-/markdown-it-footnote-3.0.1.tgz",
-      "integrity": "sha1-fzcwdHysyG4v4L+KF6cQ80eRUXo="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/markdown-it-footnote/-/markdown-it-footnote-3.0.3.tgz",
+      "integrity": "sha512-YZMSuCGVZAjzKMn+xqIco9d1cLGxbELHZ9do/TSYVzraooV8ypsppKNmUJ0fVH5ljkCInQAtFpm8Rb3eXSrt5w=="
     },
     "node_modules/markdown-it-html5-embed": {
       "version": "1.0.0",
@@ -10914,17 +10965,17 @@
       "integrity": "sha1-y5yf+RpSVawI8/09YyhuFd8KH8M="
     },
     "node_modules/markdown-it-table-of-contents": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/markdown-it-table-of-contents/-/markdown-it-table-of-contents-0.4.0.tgz",
-      "integrity": "sha512-LNLrEO0WfpQ3Kbmqh9FqcnEzEbGl11lH48lpRtWn2vkSkDjDLCSVvklIuib2oj580O7jdRq0ISQr2636LaEfPw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-table-of-contents/-/markdown-it-table-of-contents-0.6.0.tgz",
+      "integrity": "sha512-jHvEjZVEibyW97zEYg19mZCIXO16lHbvRaPDkEuOfMPBmzlI7cYczMZLMfUvwkhdOVQpIxu3gx6mgaw46KsNsQ==",
       "engines": {
         "node": ">6.4.0"
       }
     },
     "node_modules/markdown-it-video": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/markdown-it-video/-/markdown-it-video-0.4.0.tgz",
-      "integrity": "sha1-H1GjRxRWolCaOCDc7ZrRzpYb22Q="
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/markdown-it-video/-/markdown-it-video-0.6.3.tgz",
+      "integrity": "sha512-T4th1kwy0OcvyWSN4u3rqPGxvbDclpucnVSSaH3ZacbGsAts964dxokx9s/I3GYsrDCJs4ogtEeEeVP18DQj0Q=="
     },
     "node_modules/markdown-to-jsx": {
       "version": "6.11.4",
@@ -10963,26 +11014,62 @@
       }
     },
     "node_modules/markdownz": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/markdownz/-/markdownz-7.6.3.tgz",
-      "integrity": "sha512-rra0c8SV/RppWMZj9qbVUKUpz3XoG4VTEkV04uOyMs5NHqyuBEJ2cpkdLZ7COfp0tgeu8HEdetBO4GhagG05dQ==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/markdownz/-/markdownz-7.8.1.tgz",
+      "integrity": "sha512-StQcR9WM00Dl4XDCLKtKnsRe32mgvbNevbQbmAJbyaJv+kead0NJkHY82/cWFaVkOoQRf9lJ+umhKEA6a1M+Hg==",
       "dependencies": {
-        "markdown-it": "~8.4.1",
-        "markdown-it-anchor": "~5.0.2",
-        "markdown-it-container": "~2.0.0",
-        "markdown-it-emoji": "~1.2.0",
-        "markdown-it-footnote": "~3.0.1",
+        "markdown-it": "~12.3.2",
+        "markdown-it-anchor": "~8.4.1",
+        "markdown-it-container": "~3.0.0",
+        "markdown-it-emoji": "~2.0.0",
+        "markdown-it-footnote": "~3.0.3",
         "markdown-it-html5-embed": "~1.0.0",
         "markdown-it-imsize": "~2.0.1",
         "markdown-it-sub": "~1.0.0",
         "markdown-it-sup": "~1.0.0",
-        "markdown-it-table-of-contents": "~0.4.0",
-        "markdown-it-video": "~0.4.0",
-        "twemoji": "~1.4.1"
+        "markdown-it-table-of-contents": "~0.6.0",
+        "markdown-it-video": "~0.6.3",
+        "twemoji": "~13.1.0"
       },
       "peerDependencies": {
         "react": ">= 15.6",
         "react-dom": ">= 15.6"
+      }
+    },
+    "node_modules/markdownz/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
+    "node_modules/markdownz/node_modules/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/markdownz/node_modules/linkify-it": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
+      "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+      "dependencies": {
+        "uc.micro": "^1.0.1"
+      }
+    },
+    "node_modules/markdownz/node_modules/markdown-it": {
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
+      "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "~2.1.0",
+        "linkify-it": "^3.0.1",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.js"
       }
     },
     "node_modules/md5.js": {
@@ -16778,12 +16865,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/terser-webpack-plugin/node_modules/graceful-fs": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-      "dev": true
-    },
     "node_modules/terser-webpack-plugin/node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -17221,9 +17302,20 @@
       }
     },
     "node_modules/twemoji": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/twemoji/-/twemoji-1.4.1.tgz",
-      "integrity": "sha1-CEfVf+/t/3Kxv9v+4G+CJRBmNHE="
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/twemoji/-/twemoji-13.1.0.tgz",
+      "integrity": "sha512-e3fZRl2S9UQQdBFLYXtTBT6o4vidJMnpWUAhJA+yLGR+kaUTZAt3PixC0cGvvxWSuq2MSz/o0rJraOXrWw/4Ew==",
+      "dependencies": {
+        "fs-extra": "^8.0.1",
+        "jsonfile": "^5.0.0",
+        "twemoji-parser": "13.1.0",
+        "universalify": "^0.1.2"
+      }
+    },
+    "node_modules/twemoji-parser": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/twemoji-parser/-/twemoji-parser-13.1.0.tgz",
+      "integrity": "sha512-AQOzLJpYlpWMy8n+0ATyKKZzWlZBJN+G0C+5lhX7Ftc2PeEVdUU/7ns2Pn2vVje26AIZ/OHwFoUbdv6YYD/wGg=="
     },
     "node_modules/type-check": {
       "version": "0.3.2",
@@ -17416,6 +17508,14 @@
       "dev": true,
       "dependencies": {
         "imurmurhash": "^0.1.4"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/unpipe": {
@@ -19982,29 +20082,6 @@
         "react-dom": "^16.2.0"
       }
     },
-    "node_modules/zooniverse-react-components/node_modules/markdownz": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/markdownz/-/markdownz-7.7.2.tgz",
-      "integrity": "sha512-gcQT6IPeaSEZnE1tTgn3McwonTN2x1Sri214+V8eglihmmqGTPu3EluNsO7TqSRSLpIEF0KOy43EPztaf0Djdg==",
-      "dependencies": {
-        "markdown-it": "~8.4.1",
-        "markdown-it-anchor": "~5.0.2",
-        "markdown-it-container": "~2.0.0",
-        "markdown-it-emoji": "~1.2.0",
-        "markdown-it-footnote": "~3.0.1",
-        "markdown-it-html5-embed": "~1.0.0",
-        "markdown-it-imsize": "~2.0.1",
-        "markdown-it-sub": "~1.0.0",
-        "markdown-it-sup": "~1.0.0",
-        "markdown-it-table-of-contents": "~0.4.0",
-        "markdown-it-video": "~0.4.0",
-        "twemoji": "~1.4.1"
-      },
-      "peerDependencies": {
-        "react": ">= 15.6",
-        "react-dom": ">= 15.6"
-      }
-    },
     "node_modules/zooniverse-react-components/node_modules/react-select": {
       "version": "1.0.0-rc.10",
       "resolved": "https://registry.npmjs.org/react-select/-/react-select-1.0.0-rc.10.tgz",
@@ -21217,6 +21294,28 @@
         "@types/minimatch": "*",
         "@types/node": "*"
       }
+    },
+    "@types/linkify-it": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
+      "integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==",
+      "peer": true
+    },
+    "@types/markdown-it": {
+      "version": "12.2.3",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
+      "integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
+      "peer": true,
+      "requires": {
+        "@types/linkify-it": "*",
+        "@types/mdurl": "*"
+      }
+    },
+    "@types/mdurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
+      "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
+      "peer": true
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -26023,6 +26122,26 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true
     },
+    "fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "dependencies": {
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        }
+      }
+    },
     "fs-readdir-recursive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
@@ -26797,10 +26916,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-      "dev": true
+      "version": "4.2.9",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
+      "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ=="
     },
     "graceful-readlink": {
       "version": "1.0.1",
@@ -28625,6 +28743,15 @@
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
     },
+    "jsonfile": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-5.0.0.tgz",
+      "integrity": "sha512-NQRZ5CRo74MhMMC3/3r5g2k4fjodJ/wh8MxjFbCViWKFjxrnudWSY5vomh+23ZaXzAS7J3fBZIR2dV6WbmfM0w==",
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^0.1.2"
+      }
+    },
     "jsx-ast-utils": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz",
@@ -28961,25 +29088,25 @@
       }
     },
     "markdown-it-anchor": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.0.2.tgz",
-      "integrity": "sha512-AFM/woBI8QDJMS/9+MmsBMT5/AR+ImfOsunQZTZhzcTmna3rIzAzbOh5E0l6mlFM/i9666BpUtkqQ9bS7WApCg==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.4.1.tgz",
+      "integrity": "sha512-sLODeRetZ/61KkKLJElaU3NuU2z7MhXf12Ml1WJMSdwpngeofneCRF+JBbat8HiSqhniOMuTemXMrsI7hA6XyA==",
       "requires": {}
     },
     "markdown-it-container": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-it-container/-/markdown-it-container-2.0.0.tgz",
-      "integrity": "sha1-ABm0P9Au7+zi8ZYKKJX7qBpARpU="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-container/-/markdown-it-container-3.0.0.tgz",
+      "integrity": "sha512-y6oKTq4BB9OQuY/KLfk/O3ysFhB3IMYoIWhGJEidXt1NQFocFK2sA2t0NYZAMyMShAGL6x5OPIbrmXPIqaN9rw=="
     },
     "markdown-it-emoji": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/markdown-it-emoji/-/markdown-it-emoji-1.2.0.tgz",
-      "integrity": "sha1-VUqXdn1mI5NuHI1DBn8OQbeWqsM="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-emoji/-/markdown-it-emoji-2.0.0.tgz",
+      "integrity": "sha512-39j7/9vP/CPCKbEI44oV8yoPJTpvfeReTn/COgRhSpNrjWF3PfP/JUxxB0hxV6ynOY8KH8Y8aX9NMDdo6z+6YQ=="
     },
     "markdown-it-footnote": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/markdown-it-footnote/-/markdown-it-footnote-3.0.1.tgz",
-      "integrity": "sha1-fzcwdHysyG4v4L+KF6cQ80eRUXo="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/markdown-it-footnote/-/markdown-it-footnote-3.0.3.tgz",
+      "integrity": "sha512-YZMSuCGVZAjzKMn+xqIco9d1cLGxbELHZ9do/TSYVzraooV8ypsppKNmUJ0fVH5ljkCInQAtFpm8Rb3eXSrt5w=="
     },
     "markdown-it-html5-embed": {
       "version": "1.0.0",
@@ -29006,14 +29133,14 @@
       "integrity": "sha1-y5yf+RpSVawI8/09YyhuFd8KH8M="
     },
     "markdown-it-table-of-contents": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/markdown-it-table-of-contents/-/markdown-it-table-of-contents-0.4.0.tgz",
-      "integrity": "sha512-LNLrEO0WfpQ3Kbmqh9FqcnEzEbGl11lH48lpRtWn2vkSkDjDLCSVvklIuib2oj580O7jdRq0ISQr2636LaEfPw=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-table-of-contents/-/markdown-it-table-of-contents-0.6.0.tgz",
+      "integrity": "sha512-jHvEjZVEibyW97zEYg19mZCIXO16lHbvRaPDkEuOfMPBmzlI7cYczMZLMfUvwkhdOVQpIxu3gx6mgaw46KsNsQ=="
     },
     "markdown-it-video": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/markdown-it-video/-/markdown-it-video-0.4.0.tgz",
-      "integrity": "sha1-H1GjRxRWolCaOCDc7ZrRzpYb22Q="
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/markdown-it-video/-/markdown-it-video-0.6.3.tgz",
+      "integrity": "sha512-T4th1kwy0OcvyWSN4u3rqPGxvbDclpucnVSSaH3ZacbGsAts964dxokx9s/I3GYsrDCJs4ogtEeEeVP18DQj0Q=="
     },
     "markdown-to-jsx": {
       "version": "6.11.4",
@@ -29045,22 +29172,54 @@
       }
     },
     "markdownz": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/markdownz/-/markdownz-7.6.3.tgz",
-      "integrity": "sha512-rra0c8SV/RppWMZj9qbVUKUpz3XoG4VTEkV04uOyMs5NHqyuBEJ2cpkdLZ7COfp0tgeu8HEdetBO4GhagG05dQ==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/markdownz/-/markdownz-7.8.1.tgz",
+      "integrity": "sha512-StQcR9WM00Dl4XDCLKtKnsRe32mgvbNevbQbmAJbyaJv+kead0NJkHY82/cWFaVkOoQRf9lJ+umhKEA6a1M+Hg==",
       "requires": {
-        "markdown-it": "~8.4.1",
-        "markdown-it-anchor": "~5.0.2",
-        "markdown-it-container": "~2.0.0",
-        "markdown-it-emoji": "~1.2.0",
-        "markdown-it-footnote": "~3.0.1",
+        "markdown-it": "~12.3.2",
+        "markdown-it-anchor": "~8.4.1",
+        "markdown-it-container": "~3.0.0",
+        "markdown-it-emoji": "~2.0.0",
+        "markdown-it-footnote": "~3.0.3",
         "markdown-it-html5-embed": "~1.0.0",
         "markdown-it-imsize": "~2.0.1",
         "markdown-it-sub": "~1.0.0",
         "markdown-it-sup": "~1.0.0",
-        "markdown-it-table-of-contents": "~0.4.0",
-        "markdown-it-video": "~0.4.0",
-        "twemoji": "~1.4.1"
+        "markdown-it-table-of-contents": "~0.6.0",
+        "markdown-it-video": "~0.6.3",
+        "twemoji": "~13.1.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+        },
+        "entities": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+          "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w=="
+        },
+        "linkify-it": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
+          "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+          "requires": {
+            "uc.micro": "^1.0.1"
+          }
+        },
+        "markdown-it": {
+          "version": "12.3.2",
+          "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
+          "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
+          "requires": {
+            "argparse": "^2.0.1",
+            "entities": "~2.1.0",
+            "linkify-it": "^3.0.1",
+            "mdurl": "^1.0.1",
+            "uc.micro": "^1.0.5"
+          }
+        }
       }
     },
     "md5.js": {
@@ -33840,12 +33999,6 @@
             "path-is-absolute": "^1.0.0"
           }
         },
-        "graceful-fs": {
-          "version": "4.2.4",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-          "dev": true
-        },
         "json-schema-traverse": {
           "version": "0.4.1",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -34199,9 +34352,20 @@
       }
     },
     "twemoji": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/twemoji/-/twemoji-1.4.1.tgz",
-      "integrity": "sha1-CEfVf+/t/3Kxv9v+4G+CJRBmNHE="
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/twemoji/-/twemoji-13.1.0.tgz",
+      "integrity": "sha512-e3fZRl2S9UQQdBFLYXtTBT6o4vidJMnpWUAhJA+yLGR+kaUTZAt3PixC0cGvvxWSuq2MSz/o0rJraOXrWw/4Ew==",
+      "requires": {
+        "fs-extra": "^8.0.1",
+        "jsonfile": "^5.0.0",
+        "twemoji-parser": "13.1.0",
+        "universalify": "^0.1.2"
+      }
+    },
+    "twemoji-parser": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/twemoji-parser/-/twemoji-parser-13.1.0.tgz",
+      "integrity": "sha512-AQOzLJpYlpWMy8n+0ATyKKZzWlZBJN+G0C+5lhX7Ftc2PeEVdUU/7ns2Pn2vVje26AIZ/OHwFoUbdv6YYD/wGg=="
     },
     "type-check": {
       "version": "0.3.2",
@@ -34354,6 +34518,11 @@
         "imurmurhash": "^0.1.4"
       }
     },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -34472,9 +34641,9 @@
       }
     },
     "url-parse": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.3.tgz",
-      "integrity": "sha512-IIORyIQD9rvj0A4CLWsHkBBJuNqWpFQe224b6j9t/ABmquIS0qDU2pY6kl6AuOrL5OkCXHMCFNe1jBcuAggjvQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
+      "integrity": "sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==",
       "dev": true,
       "requires": {
         "querystringify": "^2.1.1",
@@ -36439,6 +36608,7 @@
     },
     "zooniverse-react-components": {
       "version": "git+ssh://git@github.com/zooniverse/Zooniverse-react-components.git#dc49e37aec4ece3a1c02493a64dd2794e9897218",
+      "integrity": "sha512-Owg7JI7TGEq483rjO0UwJPmqKr1hgfzp0TkHC4qIBpbxW+DU6ReYFFrf06B+uviJkpEsrH8JI/ZiCPWrzOUMtw==",
       "from": "zooniverse-react-components@github:zooniverse/Zooniverse-react-components#v0.9.3",
       "requires": {
         "animated-scrollto": "^1.1.0",
@@ -36452,25 +36622,6 @@
         "react-swipe": "^6.0.4"
       },
       "dependencies": {
-        "markdownz": {
-          "version": "7.7.2",
-          "resolved": "https://registry.npmjs.org/markdownz/-/markdownz-7.7.2.tgz",
-          "integrity": "sha512-gcQT6IPeaSEZnE1tTgn3McwonTN2x1Sri214+V8eglihmmqGTPu3EluNsO7TqSRSLpIEF0KOy43EPztaf0Djdg==",
-          "requires": {
-            "markdown-it": "~8.4.1",
-            "markdown-it-anchor": "~5.0.2",
-            "markdown-it-container": "~2.0.0",
-            "markdown-it-emoji": "~1.2.0",
-            "markdown-it-footnote": "~3.0.1",
-            "markdown-it-html5-embed": "~1.0.0",
-            "markdown-it-imsize": "~2.0.1",
-            "markdown-it-sub": "~1.0.0",
-            "markdown-it-sup": "~1.0.0",
-            "markdown-it-table-of-contents": "~0.4.0",
-            "markdown-it-video": "~0.4.0",
-            "twemoji": "~1.4.1"
-          }
-        },
         "react-select": {
           "version": "1.0.0-rc.10",
           "resolved": "https://registry.npmjs.org/react-select/-/react-select-1.0.0-rc.10.tgz",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "counterpart": "~0.18.1",
     "graphql-request": "~1.3.4",
     "history": "~4.6.1",
-    "markdownz": "~7.6.3",
+    "markdownz": "~7.8.1",
     "panoptes-client": "^3.0.0-rc.0",
     "prop-types": "^15.5.10",
     "react": "^16.8.6",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "engines": {
     "node": ">=14",
-    "npm": ">=6"
+    "npm": ">=7"
   },
   "author": "Zooniverse",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "graphql-request": "~1.3.4",
     "history": "~4.6.1",
     "markdownz": "~7.8.1",
-    "panoptes-client": "^3.0.0-rc.0",
+    "panoptes-client": "^3.3.4",
     "prop-types": "^15.5.10",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",


### PR DESCRIPTION
Updates markdownz to v7.8.1 and panoptes-client to v3.3.4. Both updates include dependency security updates.

Not sure if panoptes-client was on 3.0.0-rc.0 for specific reason maybe? Seemed to work ok, but couldn't login locally (on master or this branch).