### PR TITLE
Set Node to 16.14 to fix build issues

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -12,7 +12,7 @@ jobs:
     uses: zooniverse/ci-cd/.github/workflows/npm_build.yaml@main
     with:
       commit_id: ${{ github.sha }}
-      node_version: '16.x'
+      node_version: '16.14.x'
       output: 'dist'
       script: 'build'
   deploy:

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -11,7 +11,7 @@ jobs:
     uses: zooniverse/ci-cd/.github/workflows/npm_build.yaml@main
     with:
       commit_id: ${{ github.sha }}
-      node_version: '16.x'
+      node_version: '16.14.x'
       output: 'dist'
       script: 'build'
   deploy:


### PR DESCRIPTION
As noted in other repos using Node v16.15 or higher in builds (latest build issues in this repo are with Node v16.16) - builds with Node > 16.15 fail with unmatched peer dependency errors - new Node versions are more strict about nested dependencies.

This PR sets node to v16.14 to fix the builds.

I think the long term solution might be to utilize the `--legacy-peer-deps` flag. I'll create an issue for that, to document and discuss.