### PR TITLE
Update Zooniverse-React-Components to v0.9.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "redux-logger": "~2.7.4",
         "redux-thunk": "~2.1.0",
         "zoo-grommet": "~0.3.0",
-        "zooniverse-react-components": "github:zooniverse/Zooniverse-React-Components#v0.9.6"
+        "zooniverse-react-components": "github:zooniverse/Zooniverse-React-Components#v0.9.7"
       },
       "devDependencies": {
         "@babel/cli": "~7.0.0",
@@ -15235,6 +15235,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -15243,6 +15244,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -18924,8 +18926,8 @@
       }
     },
     "node_modules/zooniverse-react-components": {
-      "version": "0.9.6",
-      "resolved": "git+ssh://git@github.com/zooniverse/Zooniverse-React-Components.git#e101eb8abf2da0bb6c9f73df1c8f79fdf365ba4e",
+      "version": "0.9.7",
+      "resolved": "git+ssh://git@github.com/zooniverse/Zooniverse-React-Components.git#d6e3e30b87b387740bf08efd252a43f85e53248e",
       "license": "Apache-2.0",
       "dependencies": {
         "animated-scrollto": "^1.1.0",
@@ -18933,7 +18935,7 @@
         "grommet": "^1.8.2",
         "markdownz": "^7.8.1",
         "modal-form": "^2.9.1",
-        "panoptes-client": "^3.3.4",
+        "panoptes-client": "^4.1.0",
         "prop-types": "^15.7.2",
         "react-select": "1.0.0-rc.10",
         "react-swipe": "^6.0.4"
@@ -18945,136 +18947,6 @@
       "peerDependencies": {
         "react": "^16.2.0",
         "react-dom": "^16.2.0"
-      }
-    },
-    "node_modules/zooniverse-react-components/node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/zooniverse-react-components/node_modules/component-emitter": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
-    },
-    "node_modules/zooniverse-react-components/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/zooniverse-react-components/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/zooniverse-react-components/node_modules/formidable": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.0.1.tgz",
-      "integrity": "sha512-rjTMNbp2BpfQShhFbR3Ruk3qk2y9jKpvMW78nJgx8QKtxjDVrwbZG+wvDOmVbifHyOUOQJXxqEy6r0faRrPzTQ==",
-      "dependencies": {
-        "dezalgo": "1.0.3",
-        "hexoid": "1.0.0",
-        "once": "1.4.0",
-        "qs": "6.9.3"
-      },
-      "funding": {
-        "url": "https://ko-fi.com/tunnckoCore/commissions"
-      }
-    },
-    "node_modules/zooniverse-react-components/node_modules/formidable/node_modules/qs": {
-      "version": "6.9.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.3.tgz",
-      "integrity": "sha512-EbZYNarm6138UKKq46tdx08Yo/q9ZhFoAXAI1meAFd2GtbRDhbZY2WQSICskT0c5q99aFzLG1D4nvTk9tqfXIw==",
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/zooniverse-react-components/node_modules/json-api-client": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/json-api-client/-/json-api-client-5.1.2.tgz",
-      "integrity": "sha512-89o30CBPFQWgUlljOITT3T12/C8FPLXl47QIjvT406aAJjBLBCIVAhAQ+vtbRN7WFuBQ4LxxMolRtkadErruWg==",
-      "dependencies": {
-        "normalizeurl": "~1.0.0",
-        "superagent": "^7.1.6"
-      }
-    },
-    "node_modules/zooniverse-react-components/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/zooniverse-react-components/node_modules/mime": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
-      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/zooniverse-react-components/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
-    "node_modules/zooniverse-react-components/node_modules/panoptes-client": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-3.4.1.tgz",
-      "integrity": "sha512-jBTN754730Zd7XdAA409B7TiLAPIkuzfe0hZhK5EpTzqUgII+dP+5TzhqVHPzUZngIqTkTxx1neL0vSrygNHmA==",
-      "dependencies": {
-        "json-api-client": "~5.1.0",
-        "local-storage": "^2.0.0",
-        "sugar-client": "^2.0.0"
-      }
-    },
-    "node_modules/zooniverse-react-components/node_modules/qs": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
-      "dependencies": {
-        "side-channel": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/zooniverse-react-components/node_modules/react-select": {
@@ -19090,60 +18962,6 @@
         "react": "^0.14.9 || ^15.3.0 || ^16.0.0-rc || ^16.0",
         "react-dom": "^0.14.9 || ^15.3.0 || ^16.0.0-rc || ^16.0"
       }
-    },
-    "node_modules/zooniverse-react-components/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/zooniverse-react-components/node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/zooniverse-react-components/node_modules/superagent": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-7.1.6.tgz",
-      "integrity": "sha512-gZkVCQR1gy/oUXr+kxJMLDjla434KmSOKbx5iGD30Ql+AkJQ/YlPKECJy2nhqOsHLjGHzoDTXNSjhnvWhzKk7g==",
-      "deprecated": "Please downgrade to v7.1.5 if you need IE/ActiveXObject support OR upgrade to v8.0.0 as we no longer support IE and published an incorrect patch version (see https://github.com/visionmedia/superagent/issues/1731)",
-      "dependencies": {
-        "component-emitter": "^1.3.0",
-        "cookiejar": "^2.1.3",
-        "debug": "^4.3.4",
-        "fast-safe-stringify": "^2.1.1",
-        "form-data": "^4.0.0",
-        "formidable": "^2.0.1",
-        "methods": "^1.1.2",
-        "mime": "2.6.0",
-        "qs": "^6.10.3",
-        "readable-stream": "^3.6.0",
-        "semver": "^7.3.7"
-      },
-      "engines": {
-        "node": ">=6.4.0 <13 || >=14"
-      }
-    },
-    "node_modules/zooniverse-react-components/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   },
   "dependencies": {
@@ -20562,7 +20380,8 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz",
       "integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-jsx": {
       "version": "3.0.1",
@@ -20603,13 +20422,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ajv-keywords": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
       "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "amdefine": {
       "version": "1.0.1",
@@ -22636,7 +22457,8 @@
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.0.tgz",
           "integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "ansi-styles": {
           "version": "3.2.1",
@@ -23795,7 +23617,8 @@
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-10.0.1.tgz",
       "integrity": "sha1-8X1OUpksHUXRt3E++81ezQ5+BQY=",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-import-resolver-node": {
       "version": "0.2.3",
@@ -24426,7 +24249,8 @@
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.0.tgz",
           "integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "big.js": {
           "version": "5.2.2",
@@ -26564,13 +26388,15 @@
           "version": "2.2.7",
           "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.2.7.tgz",
           "integrity": "sha512-kCusyu/Fa0oax5ue2Id/ZqVLEk5JOWyrXHcLbD4kHoVM50MhDEWUtcHlN7RrD94I8OrWILcVltM6OllnZiHJmg==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "io-ts-reporters": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/io-ts-reporters/-/io-ts-reporters-1.2.0.tgz",
           "integrity": "sha512-wbNwb3p6q76dlqZrilZecgeBupnFijD6RRaN7418q0kNxIRJVS+8L28LcRaEevFhoCx7i0mhdPIxwpuIjGxkOw==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
@@ -27744,7 +27570,8 @@
     "markdown-it-anchor": {
       "version": "8.4.1",
       "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.4.1.tgz",
-      "integrity": "sha512-sLODeRetZ/61KkKLJElaU3NuU2z7MhXf12Ml1WJMSdwpngeofneCRF+JBbat8HiSqhniOMuTemXMrsI7hA6XyA=="
+      "integrity": "sha512-sLODeRetZ/61KkKLJElaU3NuU2z7MhXf12Ml1WJMSdwpngeofneCRF+JBbat8HiSqhniOMuTemXMrsI7hA6XyA==",
+      "requires": {}
     },
     "markdown-it-container": {
       "version": "3.0.0",
@@ -28109,7 +27936,8 @@
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.0.tgz",
           "integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "big.js": {
           "version": "5.2.2",
@@ -30043,7 +29871,8 @@
     "react-desc": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/react-desc/-/react-desc-1.4.1.tgz",
-      "integrity": "sha1-mb7d974ldZAtFZ6RlAjRGII8x4s="
+      "integrity": "sha1-mb7d974ldZAtFZ6RlAjRGII8x4s=",
+      "requires": {}
     },
     "react-dom": {
       "version": "16.8.6",
@@ -30260,7 +30089,8 @@
     "redux-devtools-extension": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-1.0.0.tgz",
-      "integrity": "sha1-+L96Kgk7ZIBUo4FNbRIK2LyL6qk="
+      "integrity": "sha1-+L96Kgk7ZIBUo4FNbRIK2LyL6qk=",
+      "requires": {}
     },
     "redux-logger": {
       "version": "2.7.4",
@@ -31197,7 +31027,8 @@
           "version": "7.4.2",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.2.tgz",
           "integrity": "sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -31653,6 +31484,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.2.0"
       },
@@ -31660,7 +31492,8 @@
         "safe-buffer": {
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
         }
       }
     },
@@ -32295,7 +32128,8 @@
           "version": "3.5.0",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.0.tgz",
           "integrity": "sha512-eyoaac3btgU8eJlvh01En8OCKzRqlLe2G5jDsCr3RiE2uLGMEEB1aaGwVVpwR8M95956tGH6R+9edC++OvzaVw==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "cacache": {
           "version": "12.0.4",
@@ -33308,7 +33142,8 @@
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.0.tgz",
           "integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "big.js": {
           "version": "5.2.2",
@@ -33825,7 +33660,8 @@
           "version": "3.5.0",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.0.tgz",
           "integrity": "sha512-eyoaac3btgU8eJlvh01En8OCKzRqlLe2G5jDsCr3RiE2uLGMEEB1aaGwVVpwR8M95956tGH6R+9edC++OvzaVw==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "ansi-regex": {
           "version": "4.1.0",
@@ -34614,114 +34450,20 @@
       }
     },
     "zooniverse-react-components": {
-      "version": "git+ssh://git@github.com/zooniverse/Zooniverse-React-Components.git#e101eb8abf2da0bb6c9f73df1c8f79fdf365ba4e",
-      "from": "zooniverse-react-components@github:zooniverse/Zooniverse-React-Components#v0.9.6",
+      "version": "git+ssh://git@github.com/zooniverse/Zooniverse-React-Components.git#d6e3e30b87b387740bf08efd252a43f85e53248e",
+      "from": "zooniverse-react-components@github:zooniverse/Zooniverse-React-Components#v0.9.7",
       "requires": {
         "animated-scrollto": "^1.1.0",
         "data-uri-to-blob": "0.0.4",
         "grommet": "^1.8.2",
         "markdownz": "^7.8.1",
         "modal-form": "^2.9.1",
-        "panoptes-client": "^3.3.4",
+        "panoptes-client": "^4.1.0",
         "prop-types": "^15.7.2",
         "react-select": "1.0.0-rc.10",
         "react-swipe": "^6.0.4"
       },
       "dependencies": {
-        "combined-stream": {
-          "version": "1.0.8",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-          "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-          "requires": {
-            "delayed-stream": "~1.0.0"
-          }
-        },
-        "component-emitter": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-          "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
-        },
-        "debug": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "form-data": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "mime-types": "^2.1.12"
-          }
-        },
-        "formidable": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.0.1.tgz",
-          "integrity": "sha512-rjTMNbp2BpfQShhFbR3Ruk3qk2y9jKpvMW78nJgx8QKtxjDVrwbZG+wvDOmVbifHyOUOQJXxqEy6r0faRrPzTQ==",
-          "requires": {
-            "dezalgo": "1.0.3",
-            "hexoid": "1.0.0",
-            "once": "1.4.0",
-            "qs": "6.9.3"
-          },
-          "dependencies": {
-            "qs": {
-              "version": "6.9.3",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.3.tgz",
-              "integrity": "sha512-EbZYNarm6138UKKq46tdx08Yo/q9ZhFoAXAI1meAFd2GtbRDhbZY2WQSICskT0c5q99aFzLG1D4nvTk9tqfXIw=="
-            }
-          }
-        },
-        "json-api-client": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/json-api-client/-/json-api-client-5.1.2.tgz",
-          "integrity": "sha512-89o30CBPFQWgUlljOITT3T12/C8FPLXl47QIjvT406aAJjBLBCIVAhAQ+vtbRN7WFuBQ4LxxMolRtkadErruWg==",
-          "requires": {
-            "normalizeurl": "~1.0.0",
-            "superagent": "^7.1.6"
-          }
-        },
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "mime": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
-          "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg=="
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "panoptes-client": {
-          "version": "3.4.1",
-          "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-3.4.1.tgz",
-          "integrity": "sha512-jBTN754730Zd7XdAA409B7TiLAPIkuzfe0hZhK5EpTzqUgII+dP+5TzhqVHPzUZngIqTkTxx1neL0vSrygNHmA==",
-          "requires": {
-            "json-api-client": "~5.1.0",
-            "local-storage": "^2.0.0",
-            "sugar-client": "^2.0.0"
-          }
-        },
-        "qs": {
-          "version": "6.11.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-          "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
-          "requires": {
-            "side-channel": "^1.0.4"
-          }
-        },
         "react-select": {
           "version": "1.0.0-rc.10",
           "resolved": "https://registry.npmjs.org/react-select/-/react-select-1.0.0-rc.10.tgz",
@@ -34731,47 +34473,6 @@
             "prop-types": "^15.5.8",
             "react-input-autosize": "^2.0.1"
           }
-        },
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        },
-        "semver": {
-          "version": "7.3.7",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "superagent": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/superagent/-/superagent-7.1.6.tgz",
-          "integrity": "sha512-gZkVCQR1gy/oUXr+kxJMLDjla434KmSOKbx5iGD30Ql+AkJQ/YlPKECJy2nhqOsHLjGHzoDTXNSjhnvWhzKk7g==",
-          "requires": {
-            "component-emitter": "^1.3.0",
-            "cookiejar": "^2.1.3",
-            "debug": "^4.3.4",
-            "fast-safe-stringify": "^2.1.1",
-            "form-data": "^4.0.0",
-            "formidable": "^2.0.1",
-            "methods": "^1.1.2",
-            "mime": "2.6.0",
-            "qs": "^6.10.3",
-            "readable-stream": "^3.6.0",
-            "semver": "^7.3.7"
-          }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "redux-logger": "~2.7.4",
     "redux-thunk": "~2.1.0",
     "zoo-grommet": "~0.3.0",
-    "zooniverse-react-components": "github:zooniverse/Zooniverse-React-Components#v0.9.6"
+    "zooniverse-react-components": "github:zooniverse/Zooniverse-React-Components#v0.9.7"
   },
   "devDependencies": {
     "@babel/cli": "~7.0.0",


### PR DESCRIPTION
Update Zooniverse-React-Components to v0.9.7 to include [panoptes-client v0.4.1](https://github.com/zooniverse/panoptes-javascript-client/blob/master/CHANGELOG.md#v410-2022-09-30)

Noting the update to ZRC only impacts the ZRC Tutorial component used by Anti-Slavery-Manuscripts.