### PR TITLE
Build: use production Node env

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start": "BABEL_ENV=development check-engines && check-dependencies && webpack-dashboard -p 3001 -- webpack-dev-server --config ./webpack.config.js",
     "test": "echo 'This project has no tests.' || true",
     "eslint": "eslint .",
-    "build": "BABEL_ENV=production check-engines && check-dependencies && webpack --config webpack.production.config.js"
+    "build": "export NODE_ENV=production ; BABEL_ENV=production check-engines && check-dependencies && webpack --config webpack.production.config.js"
   },
   "engines": {
     "node": ">=18",


### PR DESCRIPTION
## PR Overview

This PR fixes an issue where the build process incorrectly builds targeting the staging/dev environment, instead of the production environment.